### PR TITLE
Remove inline styles from old events

### DIFF
--- a/_events/2021111-discussion-for-building-resilience-trainees-of-color.md
+++ b/_events/2021111-discussion-for-building-resilience-trainees-of-color.md
@@ -15,15 +15,13 @@ topic:
 - Wellness
 updated_at: 2020-12-21 16:41:51.000000000 Z
 ---
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">This event is only for NIH Intramural Trainees currently in our
+<span>This event is only for NIH Intramural Trainees currently in our
 postbac, graduate student, and postdoc programs.  This session will be
 held online via Zoom and the link will be distributed in NIH Trainee
 Listserv announcements. If you need the link immediately please email
 OITE@nih.gov. </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">The trainee of color discussion groups offers a warm and
+<span>The trainee of color discussion groups offers a warm and
 welcoming environment for trainees of color to engage in a safe
 space. Through the sharing of unique challenges and experiences,
 building community, and celebrating difference this groups
@@ -32,8 +30,7 @@ at NIH. Whether you are feeling isolated, unsure or just want to expand
 your community, this group is for you.  This session is open to trainees
 at all levels.  </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Please join us for a discussion with OITE Wellness Advisor, Jenn
+<span>Please join us for a discussion with OITE Wellness Advisor, Jenn
 Wiggins. The discussion group provides a welcoming and confidential
 space to explore positive and proactive ways to build resilience and
 self-care skills.</span>

--- a/_events/2021112-becoming-a-resilient-scientist-series-v-feedback-resilience.md
+++ b/_events/2021112-becoming-a-resilient-scientist-series-v-feedback-resilience.md
@@ -65,7 +65,7 @@ Session 5 -- Jan: V. Developing Feedback Resilience
 
 Session 6 -- Feb: VI. Managing Up to Maximize Mentoring Relationships
 
-<span style="font-size: 11px;"> </span>
+<span> </span>
 
 
 

--- a/_events/2021112-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
+++ b/_events/2021112-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
@@ -15,13 +15,13 @@ topic:
 - Wellness
 updated_at: 2020-12-28 20:40:29.000000000 Z
 ---
-<span style="font-size: 10pt;">This event is only for NIH Intramural
+<span>This event is only for NIH Intramural
 Trainees currently in our postbac, graduate student, and postdoc
 programs.  This session will be held online via Zoom and the link will
 be distributed in NIH Trainee Listserv announcements. If you need the
 link immediately please email OITE@nih.gov. </span>
 
-<span style="font-size: 10pt;">Mental health conditions like anxiety,
+<span>Mental health conditions like anxiety,
 depression, OCD, ADHD/ADD, ASD sometimes occur as natural systems become
 dysregulated and they can often exacerbate each other. While
 experiencing the effects of anxiety and depression
@@ -30,13 +30,13 @@ feelings. Come share your thoughts and learn from each
 other's experiences in dealing with anxiety, depression, and other
 challenges. </span>
 
-<span style="font-size: 10pt;">Please join us for an online discussion
+<span>Please join us for an online discussion
 with OITE Wellness Advisor, Annie Scheiner.  The discussion group
 provides a confidential and welcoming space to explore positive and
 proactive methods to build resilience and self-care skills with other
 trainees having similar experiences.  Even if you can\'t join us for the
 entire hour, we encourage you to still attend.  </span>
 
-<span style="font-size: 10pt;"> </span>
+<span> </span>
 
  

--- a/_events/2021113-discussion-for-building-resilience-coping-with-covid-winter-and-uncertainty.md
+++ b/_events/2021113-discussion-for-building-resilience-coping-with-covid-winter-and-uncertainty.md
@@ -15,13 +15,13 @@ topic:
 - Wellness
 updated_at: 2020-12-28 20:40:14.000000000 Z
 ---
-<span style="font-size: 10pt;">This event is only for NIH Intramural
+<span>This event is only for NIH Intramural
 Trainees currently in our postbac, graduate student, and postdoc
 programs. Zoom link will be distributed via NIH Trainee Listservs the
 morning of the event. If you need the link immediately please email
 OITE@nih.gov.</span>
 
-<span style="font-size: 10pt;">Winter is here.  The colder weather,
+<span>Winter is here.  The colder weather,
 shorter days, and social distancing will begin to present us with new
 challenges for our wellness. Additionally, the persistent feelings of
 uncertainty about the future continue to trouble many of us. Just
@@ -30,7 +30,7 @@ to cope with this uncertainty, a COVID winter may disrupt them again.
 This discussion will focus on how to reevaluate coping tools for the
 winter and continued uncertainty.   </span>
 
-<span style="font-size: 10pt;">Please join us for a discussion with OITE
+<span>Please join us for a discussion with OITE
 Wellness Advisor,Liann Seiter. The discussion group provides a welcoming
 and confidential space to explore positive and proactive ways to build
 resilience and self-care skills.</span>

--- a/_events/2021113-ethics-in-research-training-for-postbacs-and-grad-students.md
+++ b/_events/2021113-ethics-in-research-training-for-postbacs-and-grad-students.md
@@ -16,7 +16,7 @@ updated_at: 2020-11-17 16:51:22.000000000 Z
 ---
  
 
-<span style="font-size: 11.5052px; line-height: 17.833px;">Training in
+<span>Training in
 Responsible Conduct of Research is an essential component of your
 development as a scientist.</span>
 
@@ -45,22 +45,20 @@ Topics to be covered include:
 
 **\*This course is only for postbacs and grad students.  Note: If you
 took this course at NIH last year, you do not need to take it again.**
-{: style="font-size: 11.5052px; line-height: 17.833px;"}
 
-<span style="font-size: 8.5pt;">The Following IC offers and requires
-their own ethics training: **<span style="font-size:
-11.5052px;">NIEHS</span>**{: style="font-size: 11.5052px;"}. *<span
-style="font-size: 11.5052px;">This course will not substitute for those
-requirements.</span>*{: style="font-size: 11.5052px;"}</span>
-{: style="margin: 0in 0in 0.0001pt; font-size: 11.5052px; color: #333333; text-size-adjust: auto; line-height: 13.35pt;"}
+
+<span>The Following IC offers and requires
+their own ethics training: **<span>NIEHS</span>**. *<span>This course will not substitute for those
+requirements.</span>*</span>
+
 
  
-{: style="margin: 0in 0in 0.0001pt; font-size: 11.5052px; color: #333333; text-size-adjust: auto; line-height: 13.35pt;"}
+
 
 The following IC\'s **require** this training: CC, NCATS, NCCIH,
 NCI-CCR, NCI-DCEG, NEI, NHLBI, NIA, NIAID, NIAMS, NIBIB, NICHD, NIDA,
 NIDCD, NIDDK, NIMH, NINR.  
-{: style="margin: 0in 0in 0.0001pt; font-size: 11.5052px; color: #333333; text-size-adjust: auto; line-height: 13.35pt;"}
+
 
  
 
@@ -72,13 +70,10 @@ address should contact [Dr. Andrea Naranjo
 Erazo](mailto:andrea.naranjo-erazo@nih.gov) to register for this
 training.
 
-<span style="font-size: 8.5pt;">If you have further questions, please
-contact your institute\'s [<span style="padding: 0in; font-size:
-11.5052px; border: 1pt none windowtext;">Training Director</span>][1]{:
-style="font-size: 11.5052px;"} or <span style="padding: 0in; font-size:
-11.5052px; border: 1pt none windowtext;">[Dr. Andrea Naranjo
+<span>If you have further questions, please
+contact your institute\'s [<span>Training Director</span>][1] or <span>[Dr. Andrea Naranjo
 Erazo](mailto:andrea.naranjo-erazo@nih.gov).</span></span>
-{: style="font-size: 11.5052px; color: #333333; text-size-adjust: auto; line-height: 17.833px;"}
+
 
 
 

--- a/_events/2021114-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
+++ b/_events/2021114-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
@@ -31,7 +31,7 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/2021115-cancelled-discussion-for-building-resilience-managing-academic-stressors.md
+++ b/_events/2021115-cancelled-discussion-for-building-resilience-managing-academic-stressors.md
@@ -13,10 +13,10 @@ topic:
 - Wellness
 updated_at: 2021-01-11 21:10:12.000000000 Z
 ---
-<span style="font-size: 10pt;">This event conflicts with the NIH Town
+<span>This event conflicts with the NIH Town
 Hall and has been canceled.  </span>
 
-<span style="font-size: 10pt;">So many of our postbacs are currently
+<span>So many of our postbacs are currently
 studying for and worried about MCATs, GREs, and other standardized tests
 coupled with applications and interviews. The pandemic has also brought
 many changes to the current testing and application season. Not only are

--- a/_events/2021115-md-and-md-phd-application-q-a-session.md
+++ b/_events/2021115-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2020-12-18 23:04:24.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/2021121-discussion-for-building-resilience-international-trainees.md
+++ b/_events/2021121-discussion-for-building-resilience-international-trainees.md
@@ -15,13 +15,13 @@ topic:
 - Wellness
 updated_at: 2020-12-21 17:14:15.000000000 Z
 ---
-<span style="font-size: 10pt;">This event is only for NIH Intramural
+<span>This event is only for NIH Intramural
 Trainees currently in our postbac, graduate student, and postdoc
 programs.  This session will be held online via Zoom and the link will
 be distributed in NIH Trainee Listserv announcements. If you need the
 link immediately please email OITE@nih.gov. </span>
 
-<span style="font-size: 10pt;">International trainees often face a
+<span>International trainees often face a
 unique set of challenges. Whether it is the distance from family and
 home, learning a new culture, visa stress, or discovering a new sense of
 community, these challenges can cause fellows to feel overwhelmed,
@@ -31,7 +31,7 @@ are other trainees having similar experiences.  Additionally, the
 group offers space to dialogue around U.S. culture, coping tools and to
 learn from each other. </span>
 
-<span style="font-size: 10pt;">Please join us for a discussion with OITE
+<span>Please join us for a discussion with OITE
 Wellness Advisor, Emilie Gomart. The discussion group provides a
 welcoming and confidential space to explore positive and proactive ways
 to build resilience and self-care skills.</span>

--- a/_events/2021121-discussion-for-building-resilience-lgbtqia-trainees.md
+++ b/_events/2021121-discussion-for-building-resilience-lgbtqia-trainees.md
@@ -15,13 +15,13 @@ topic:
 - Wellness
 updated_at: 2020-12-21 17:15:36.000000000 Z
 ---
-<span style="font-size: 10pt;">This event is only for NIH Intramural
+<span>This event is only for NIH Intramural
 Trainees currently in our postbac, graduate student, and postdoc
 programs.  This session will be held online via Zoom and the link will
 be distributed in NIH Trainee Listserv announcements. If you need the
 link immediately please email OITE@nih.gov. </span>
 
-<span style="font-size: 10pt;">Please join this warm and welcoming group
+<span>Please join this warm and welcoming group
 of LGBTQI+ trainees to enjoy a safe space and be yourself. Let's share
 our unique resources, experiences and challenges to help you feel
 connected and supported during your time as an NIH trainee. Whether you
@@ -31,14 +31,14 @@ connected to our community; come join us wherever you are on your own
 personal journey.  This session is open to trainees at all levels
 (postbac, grad, and postdoc).</span>
 
-<span style="font-size: 10pt;">Please join us for an online discussion
+<span>Please join us for an online discussion
 with OITE Wellness Advisor, Lissa Mantell.  The discussion group
 provides a welcoming and confidential space to explore positive and
 proactive ways to build resilience and self-care skills. Even if you
 can\'t join us for the entire hour, we encourage you to still
 attend. </span>
 
-<span style="font-family: arial, helvetica, sans-serif;"> </span>
+<span> </span>
 
  
 

--- a/_events/2021121-discussion-for-building-resilience-self-compassion-for-trainees.md
+++ b/_events/2021121-discussion-for-building-resilience-self-compassion-for-trainees.md
@@ -15,14 +15,12 @@ topic:
 - Wellness
 updated_at: 2020-12-21 17:16:58.000000000 Z
 ---
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">This session is only for NIH Intramural Trainees.  This online
+<span>This session is only for NIH Intramural Trainees.  This online
 session will be held with Zoom.  The meeting link will be distributed
 via the NIH Trainee Listservs. If you need the link immediately please
 email OITE@nih.gov.</span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Most of us spend more time in our heads or talking to ourselves
+<span>Most of us spend more time in our heads or talking to ourselves
 than we will ever spend talking with others. Would you say to others, a
 good friend for example, the types of things you say to yourself? Using
 the principles of self-compassion, we'll examine how the messaging we
@@ -32,8 +30,7 @@ understanding that is rooted in kindness for us and those around us.
 Join our conversation as we explore opportunities to understand what
 self-compassion is and how you can put it to work for you! </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Please join us for an online discussion with OITE Wellness
+<span>Please join us for an online discussion with OITE Wellness
 Advisor, Lissa Mantell.  The discussion group provides a welcoming and
 confidential space to explore positive and proactive ways to build
 resilience and self-care skills. Even if you can\'t join us for the

--- a/_events/2021121-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch-taking-ownership-of-your-career-developing-a-plan.md
+++ b/_events/2021121-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch-taking-ownership-of-your-career-developing-a-plan.md
@@ -35,7 +35,7 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/2021122-discussion-for-building-resilience-unhealthy-habits.md
+++ b/_events/2021122-discussion-for-building-resilience-unhealthy-habits.md
@@ -15,15 +15,13 @@ topic:
 - Wellness
 updated_at: 2020-12-28 20:40:02.000000000 Z
 ---
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">This event is only for NIH Intramural Trainees currently in our
+<span>This event is only for NIH Intramural Trainees currently in our
 postbac, graduate student, and postdoc programs.  This session will be
 held online via Zoom and the link will be distributed in NIH Trainee
 Listserv announcements. If you need the link immediately please email
 OITE@nih.gov. </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Habits are hard to break.  Are you tired of your unhealthy habits
+<span>Habits are hard to break.  Are you tired of your unhealthy habits
 bringing you down?  Some of these unhealthy habits could include
 excessive cellphone use, indulging in comfort foods, or constantly
 thinking about work after work hours. Come to a safe space where habit
@@ -32,8 +30,7 @@ research on habit change, along with some compassionate support, you can
 gain the tools you need to develop a happier and healthier you and
 thrive in our new version of normal. </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Please join us for an online discussion with OITE Wellness
+<span>Please join us for an online discussion with OITE Wellness
 Advisor, Marin Rieger.   Building your resiliency and self-care skills
 now will help you to successfully navigate through periods of growth,
 and will serve you well throughout your academic and career path.  Even

--- a/_events/2021125-discussion-for-building-resilience-trainees-of-color.md
+++ b/_events/2021125-discussion-for-building-resilience-trainees-of-color.md
@@ -15,15 +15,13 @@ topic:
 - Wellness
 updated_at: 2020-12-21 16:43:04.000000000 Z
 ---
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">This event is only for NIH Intramural Trainees currently in our
+<span>This event is only for NIH Intramural Trainees currently in our
 postbac, graduate student, and postdoc programs.  This session will be
 held online via Zoom and the link will be distributed in NIH Trainee
 Listserv announcements. If you need the link immediately please email
 OITE@nih.gov. </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">The trainee of color discussion groups offers a warm and
+<span>The trainee of color discussion groups offers a warm and
 welcoming environment for trainees of color to engage in a safe
 space. Through the sharing of unique challenges and experiences,
 building community, and celebrating difference this groups
@@ -32,8 +30,7 @@ at NIH. Whether you are feeling isolated, unsure or just want to expand
 your community, this group is for you.  This session is open to trainees
 at all levels.  </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Please join us for a discussion with OITE Wellness Advisor, Jenn
+<span>Please join us for a discussion with OITE Wellness Advisor, Jenn
 Wiggins. The discussion group provides a welcoming and confidential
 space to explore positive and proactive ways to build resilience and
 self-care skills.</span>

--- a/_events/2021126-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
+++ b/_events/2021126-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
@@ -15,13 +15,13 @@ topic:
 - Wellness
 updated_at: 2020-12-28 20:39:30.000000000 Z
 ---
-<span style="font-size: 10pt;">This event is only for NIH Intramural
+<span>This event is only for NIH Intramural
 Trainees currently in our postbac, graduate student, and postdoc
 programs.  This session will be held online via Zoom and the link will
 be distributed in NIH Trainee Listserv announcements. If you need the
 link immediately please email OITE@nih.gov. </span>
 
-<span style="font-size: 10pt;">Mental health conditions like anxiety,
+<span>Mental health conditions like anxiety,
 depression, OCD, ADHD/ADD, ASD sometimes occur as natural systems become
 dysregulated and they can often exacerbate each other. While
 experiencing the effects of anxiety and depression
@@ -30,13 +30,13 @@ feelings. Come share your thoughts and learn from each
 other's experiences in dealing with anxiety, depression, and other
 challenges. </span>
 
-<span style="font-size: 10pt;">Please join us for an online discussion
+<span>Please join us for an online discussion
 with OITE Wellness Advisor, Annie Scheiner.  The discussion group
 provides a confidential and welcoming space to explore positive and
 proactive methods to build resilience and self-care skills with other
 trainees having similar experiences.  Even if you can\'t join us for the
 entire hour, we encourage you to still attend.  </span>
 
-<span style="font-size: 10pt;"> </span>
+<span> </span>
 
  

--- a/_events/2021126-discussion-for-building-resilience-processing-loss-transition.md
+++ b/_events/2021126-discussion-for-building-resilience-processing-loss-transition.md
@@ -15,13 +15,13 @@ topic:
 - Wellness
 updated_at: 2020-12-28 20:39:47.000000000 Z
 ---
-<span style="font-size: 10pt;">This event is only for NIH Intramural
+<span>This event is only for NIH Intramural
 Trainees currently in our postbac, graduate student, and postdoc
 programs.  This session will be held online via Zoom and the link will
 be distributed in NIH Trainee Listserv announcements. If you need the
 link immediately please email OITE@nih.gov. </span>
 
-<span style="font-size: 10pt;">Grief comes in many forms and the process
+<span>Grief comes in many forms and the process
 of grieving is uniquely individual, but regardless of where you are
 in your process we can talk about ways to move forward. The current
 state of the pandemic has led to widespread feelings of loss and
@@ -31,7 +31,7 @@ of loss, significant change, and/or transition. Being mindful of our
 feelings is one way to start processing grief, but we call also share
 other strategies and brainstorm together.  </span>
 
-<span style="font-size: 10pt;">Please join us for a discussion with OITE
+<span>Please join us for a discussion with OITE
 Wellness Advisor, Annie Scheiner. The discussion group provides a
 welcoming and confidential space to explore positive and proactive ways
 to build resilience and self-care skills.</span>

--- a/_events/2021127-discussion-for-building-resilience-coping-with-covid-winter-and-uncertainty.md
+++ b/_events/2021127-discussion-for-building-resilience-coping-with-covid-winter-and-uncertainty.md
@@ -15,13 +15,13 @@ topic:
 - Wellness
 updated_at: 2020-12-21 17:05:12.000000000 Z
 ---
-<span style="font-size: 10pt;">This event is only for NIH Intramural
+<span>This event is only for NIH Intramural
 Trainees currently in our postbac, graduate student, and postdoc
 programs. Zoom link will be distributed via NIH Trainee Listservs the
 morning of the event. If you need the link immediately please email
 OITE@nih.gov.</span>
 
-<span style="font-size: 10pt;">Winter is here.  The colder weather,
+<span>Winter is here.  The colder weather,
 shorter days, and social distancing will begin to present us with new
 challenges for our wellness. Additionally, the persistent feelings of
 uncertainty about the future continue to trouble many of us. Just
@@ -30,7 +30,7 @@ to cope with this uncertainty, a COVID winter may disrupt them again.
 This discussion will focus on how to reevaluate coping tools for the
 winter and continued uncertainty.   </span>
 
-<span style="font-size: 10pt;">Please join us for a discussion with OITE
+<span>Please join us for a discussion with OITE
 Wellness Advisor, Fabian Drain. The discussion group provides a
 welcoming and confidential space to explore positive and proactive ways
 to build resilience and self-care skills.</span>

--- a/_events/2021128-discussion-for-building-resilience-job-search-stress.md
+++ b/_events/2021128-discussion-for-building-resilience-job-search-stress.md
@@ -15,15 +15,13 @@ topic:
 - Wellness
 updated_at: 2020-12-28 20:39:15.000000000 Z
 ---
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">This event is only for NIH Intramural Trainees currently in our
+<span>This event is only for NIH Intramural Trainees currently in our
 postbac, graduate student, and postdoc programs.  This session will be
 held online via Zoom and the link will be distributed in NIH Trainee
 Listserv announcements. If you need the link immediately please email
 OITE@nih.gov. </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Networking, career planning and job searches take an enormous
+<span>Networking, career planning and job searches take an enormous
 amount of time and energy, with many ups and downs throughout. The
 coronavirus pandemic adds layers of difficulty to this process. When
 folks are in the process, the focus is often on the search itself rather
@@ -35,8 +33,7 @@ or in the final negotiations for a new job, it is always a good time to
 build resilience and self-care skills that will help you successfully
 navigate through periods of transition and change.  </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Please join us for a discussion with OITE Wellness Advisor, Kelly
+<span>Please join us for a discussion with OITE Wellness Advisor, Kelly
 Donahue. The discussion group provides a welcoming and confidential
 space to explore positive and proactive ways to build resilience and
 self-care skills.</span>

--- a/_events/2021128-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
+++ b/_events/2021128-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
@@ -31,7 +31,7 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/2021129-discussion-for-building-resilience-managing-academic-stressors.md
+++ b/_events/2021129-discussion-for-building-resilience-managing-academic-stressors.md
@@ -13,13 +13,13 @@ topic:
 - Wellness
 updated_at: 2020-12-28 20:40:58.000000000 Z
 ---
-<span style="font-size: 10pt;">This event is only for NIH Intramural
+<span>This event is only for NIH Intramural
 Trainees currently in our postbac program.  This session will be held
 online via Zoom and the link will be distributed in NIH Trainee Listserv
 announcements. If you need the link immediately please email
 OITE@nih.gov. </span>
 
-<span style="font-size: 10pt;">So many of our postbacs are currently
+<span>So many of our postbacs are currently
 studying for and worried about MCATs, GREs, and other standardized tests
 coupled with applications and interviews. The pandemic has also brought
 many changes to the current testing and application season. Not only are
@@ -30,7 +30,7 @@ each other how to build their resilience and self-care skills so
 that they can cope effectively during this stressful time and ultimately
 reach their career goals.  </span>
 
-<span style="font-size: 10pt;">Please join us for a discussion with OITE
+<span>Please join us for a discussion with OITE
 Wellness Advisor, Erin Gates. The discussion group provides a welcoming
 and confidential space to explore positive and proactive ways to build
 resilience and self-care skills.</span>

--- a/_events/2021129-md-and-md-phd-application-q-a-session.md
+++ b/_events/2021129-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2020-12-18 23:05:10.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/202115-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
+++ b/_events/202115-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
@@ -16,8 +16,7 @@ updated_at: 2020-12-04 18:13:41.000000000 Z
 **We will be doing this orientation virtually, please register here and
 we will make sure you get the link to join.**
 
-**\*\*NOTE: This Orientation is for <span style="text-decoration:
-underline;">Graduate Students and Postdocs </span>\*\***
+**\*\*NOTE: This Orientation is for <span>Graduate Students and Postdocs </span>\*\***
 
 Just arrived at the NIH? Wondering how to make the most of your time
 here? Want to set goals and establish expectations with your mentor?

--- a/_events/202117-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
+++ b/_events/202117-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
@@ -15,13 +15,13 @@ topic:
 - Wellness
 updated_at: 2020-12-28 20:37:40.000000000 Z
 ---
-<span style="font-size: 10pt;">This event is only for NIH Intramural
+<span>This event is only for NIH Intramural
 Trainees currently in our postbac, graduate student, and postdoc
 programs.  This session will be held online via Zoom and the link will
 be distributed in NIH Trainee Listserv announcements. If you need the
 link immediately please email OITE@nih.gov. </span>
 
-<span style="font-size: 10pt;">Mental health conditions like anxiety,
+<span>Mental health conditions like anxiety,
 depression, OCD, ADHD/ADD, ASD sometimes occur as natural systems become
 dysregulated and they can often exacerbate each other. While
 experiencing the effects of anxiety and depression
@@ -30,13 +30,13 @@ feelings. Come share your thoughts and learn from each
 other's experiences in dealing with anxiety, depression, and other
 challenges. </span>
 
-<span style="font-size: 10pt;">Please join us for an online discussion
+<span>Please join us for an online discussion
 with OITE Wellness Advisor, Kelly Donahue.  The discussion group
 provides a confidential and welcoming space to explore positive and
 proactive methods to build resilience and self-care skills with other
 trainees having similar experiences.  Even if you can\'t join us for the
 entire hour, we encourage you to still attend.  </span>
 
-<span style="font-size: 10pt;"> </span>
+<span> </span>
 
  

--- a/_events/202117-discussion-for-building-resilience-international-trainees.md
+++ b/_events/202117-discussion-for-building-resilience-international-trainees.md
@@ -15,13 +15,13 @@ topic:
 - Wellness
 updated_at: 2020-12-21 17:10:40.000000000 Z
 ---
-<span style="font-size: 10pt;">This event is only for NIH Intramural
+<span>This event is only for NIH Intramural
 Trainees currently in our postbac, graduate student, and postdoc
 programs.  This session will be held online via Zoom and the link will
 be distributed in NIH Trainee Listserv announcements. If you need the
 link immediately please email OITE@nih.gov. </span>
 
-<span style="font-size: 10pt;">International trainees often face a
+<span>International trainees often face a
 unique set of challenges. Whether it is the distance from family and
 home, learning a new culture, visa stress, or discovering a new sense of
 community, these challenges can cause fellows to feel overwhelmed,
@@ -31,7 +31,7 @@ are other trainees having similar experiences.  Additionally, the
 group offers space to dialogue around U.S. culture, coping tools and to
 learn from each other. </span>
 
-<span style="font-size: 10pt;">Please join us for a discussion with OITE
+<span>Please join us for a discussion with OITE
 Wellness Advisor, Emilie Gomart. The discussion group provides a
 welcoming and confidential space to explore positive and proactive ways
 to build resilience and self-care skills.</span>

--- a/_events/202117-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
+++ b/_events/202117-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
@@ -31,7 +31,7 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/202118-discussion-for-building-resilience-addictive-behaviors.md
+++ b/_events/202118-discussion-for-building-resilience-addictive-behaviors.md
@@ -15,15 +15,13 @@ topic:
 - Wellness
 updated_at: 2020-12-21 17:20:13.000000000 Z
 ---
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">This event is only for NIH Intramural Trainees currently in our
+<span>This event is only for NIH Intramural Trainees currently in our
 postbac, graduate student, and postdoc programs.  This session will be
 held online via Zoom and the link will be distributed in NIH Trainee
 Listserv announcements. If you need the link immediately please email
 OITE@nih.gov. </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Habits are hard to break and when we are faced with a monumental
+<span>Habits are hard to break and when we are faced with a monumental
 shift in our day to day lives, isolation from whom and what we love, and
 fear about the future, we are likely to rely on habits even more than
 usual.  If you are struggling to make sense of your own addictive
@@ -33,8 +31,7 @@ with some compassionate support, you can gain the tools you need to
 develop a happier and healthier you and thrive in our new version of
 normal. </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Please join us for an online discussion with OITE Wellness
+<span>Please join us for an online discussion with OITE Wellness
 Advisor, Marin Rieger.   Building your resiliency and self-care skills
 now will help you to successfully navigate through periods of growth,
 and will serve you well throughout your academic and career path.  Even

--- a/_events/2021210-discussion-for-building-resilience-coping-with-covid-winter-and-uncertainty.md
+++ b/_events/2021210-discussion-for-building-resilience-coping-with-covid-winter-and-uncertainty.md
@@ -15,13 +15,13 @@ topic:
 - Wellness
 updated_at: 2021-01-29 16:52:13.000000000 Z
 ---
-<span style="font-family: arial, helvetica, sans-serif;">This event is
+<span>This event is
 only for NIH Intramural Trainees currently in our postbac, graduate
 student, and postdoc programs. Zoom link will be distributed via NIH
 Trainee Listservs the morning of the event. If you need the link
 immediately please email OITE@nih.gov.</span>
 
-<span style="font-family: arial, helvetica, sans-serif;">Winter is
+<span>Winter is
 here.  The colder weather, shorter days, and social distancing will
 begin to present us with new challenges for our wellness. Additionally,
 the persistent feelings of uncertainty about the future continue
@@ -31,7 +31,7 @@ COVID winter may disrupt them again. This discussion will focus on how
 to reevaluate coping tools for the winter and continued
 uncertainty.   </span>
 
-<span style="font-family: arial, helvetica, sans-serif;">Please join us
+<span>Please join us
 for a discussion with OITE Wellness Advisor, Liann Seiter. The
 discussion group provides a welcoming and confidential space to explore
 positive and proactive ways to build resilience and self-care

--- a/_events/2021210-scientists-teaching-science-90-minute-workshop-pm-session.md
+++ b/_events/2021210-scientists-teaching-science-90-minute-workshop-pm-session.md
@@ -13,7 +13,7 @@ topic:
 - Teaching/Mentoring
 updated_at: 2021-02-01 21:40:22.000000000 Z
 ---
-<span style="font-size: 11.5052px;">Are you interested in learning the
+<span>Are you interested in learning the
 basics of successful teaching? Are you considering a career in
 education? If you answered \'yes\' to either of these questions then
 register for the OITE workshop \"Scientists Teaching Science: An

--- a/_events/2021211-discussion-for-building-resilience-processing-loss-transition.md
+++ b/_events/2021211-discussion-for-building-resilience-processing-loss-transition.md
@@ -15,15 +15,15 @@ topic:
 - Wellness
 updated_at: 2021-01-29 16:54:00.000000000 Z
 ---
-<span style="font-family: arial, helvetica, sans-serif;">This event is
+<span>This event is
 only for NIH Intramural Trainees currently in our postbac, graduate
 student, and postdoc programs.  This session will be held online via
 Zoom and the link will be distributed in NIH Trainee Listserv
 announcements. If you need the link immediately please email
 OITE@nih.gov. </span>
-{: style="text-align: left;"}
 
-<span style="font-family: arial, helvetica, sans-serif;">Grief comes in
+
+<span>Grief comes in
 many forms and the process of grieving is uniquely individual, but
 regardless of where you are in your process we can talk about ways to
 move forward. The current state of the pandemic
@@ -33,11 +33,10 @@ group, we can talk about the experience of loss, significant change,
 and/or transition. Being mindful of our feelings is one way to start
 processing grief, but we call also share other strategies and brainstorm
 together.  </span>
-{: style="text-align: left;"}
 
-<span style="font-family: arial, helvetica, sans-serif;">Please join us
+
+<span>Please join us
 for a discussion with OITE Wellness Advisor, Kelly Donahue. The
 discussion group provides a welcoming and confidential space to explore
 positive and proactive ways to build resilience and self-care
 skills.</span>
-{: style="text-align: left;"}

--- a/_events/2021211-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
+++ b/_events/2021211-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
@@ -31,7 +31,7 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/2021212-discussion-for-building-resilience-managing-academic-stressors.md
+++ b/_events/2021212-discussion-for-building-resilience-managing-academic-stressors.md
@@ -13,13 +13,13 @@ topic:
 - Wellness
 updated_at: 2021-01-29 16:55:52.000000000 Z
 ---
-<span style="font-size: 10pt;">This event is only for NIH Intramural
+<span>This event is only for NIH Intramural
 Trainees currently in our postbac program.  This session will be held
 online via Zoom and the link will be distributed in NIH Trainee Listserv
 announcements. If you need the link immediately please email
 OITE@nih.gov. </span>
 
-<span style="font-size: 10pt;">So many of our postbacs are currently
+<span>So many of our postbacs are currently
 studying for and worried about MCATs, GREs, and other standardized tests
 coupled with applications and interviews. The pandemic has also brought
 many changes to the current testing and application season. Not only are
@@ -30,7 +30,7 @@ each other how to build their resilience and self-care skills so
 that they can cope effectively during this stressful time and ultimately
 reach their career goals.  </span>
 
-<span style="font-size: 10pt;">Please join us for a discussion with OITE
+<span>Please join us for a discussion with OITE
 Wellness Advisor, Erin Gates. The discussion group provides a welcoming
 and confidential space to explore positive and proactive ways to build
 resilience and self-care skills.</span>

--- a/_events/2021212-md-and-md-phd-application-q-a-session.md
+++ b/_events/2021212-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-02-04 16:18:43.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/2021216-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
+++ b/_events/2021216-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
@@ -34,8 +34,8 @@ Annie Scheiner.  The discussion group provides a confidential and
 welcoming space to explore positive and proactive methods to build
 resilience and self-care skills with other trainees having similar
 experiences.  Even if you can\'t join us for the entire hour, we
-encourage you to still attend. <span style="font-size: 10pt;"> </span>
+encourage you to still attend. <span> </span>
 
-<span style="font-size: 10pt;"> </span>
+<span> </span>
 
  

--- a/_events/2021218-discussion-for-building-resilience-lgbtqia-trainees.md
+++ b/_events/2021218-discussion-for-building-resilience-lgbtqia-trainees.md
@@ -37,8 +37,7 @@ confidential space to explore positive and proactive ways to build
 resilience and self-care skills. Even if you can\'t join us for the
 entire hour, we encourage you to still attend. 
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;"> </span>
+<span> </span>
 
  
 

--- a/_events/2021218-discussion-for-building-resilience-self-compassion-for-trainees.md
+++ b/_events/2021218-discussion-for-building-resilience-self-compassion-for-trainees.md
@@ -15,14 +15,12 @@ topic:
 - Wellness
 updated_at: 2021-02-03 19:11:13.000000000 Z
 ---
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">This session is only for NIH Intramural Trainees.  This online
+<span>This session is only for NIH Intramural Trainees.  This online
 session will be held with Zoom.  The meeting link will be distributed
 via the NIH Trainee Listservs. If you need the link immediately please
 email OITE@nih.gov.</span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Most of us spend more time in our heads or talking to ourselves
+<span>Most of us spend more time in our heads or talking to ourselves
 than we will ever spend talking with others. Would you say to others, a
 good friend for example, the types of things you say to yourself? Using
 the principles of self-compassion, we'll examine how the messaging we
@@ -32,15 +30,13 @@ understanding that is rooted in kindness for us and those around us.
 Join our conversation as we explore opportunities to understand what
 self-compassion is and how you can put it to work for you! </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Please join us for an online discussion with OITE Wellness
+<span>Please join us for an online discussion with OITE Wellness
 Advisor, Lissa Mantell.  The discussion group provides a welcoming and
 confidential space to explore positive and proactive ways to build
 resilience and self-care skills. Even if you can\'t join us for the
 entire hour, we encourage you to still attend.  </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;"> </span>
+<span> </span>
 
  
 

--- a/_events/2021218-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
+++ b/_events/2021218-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
@@ -31,7 +31,7 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/202122-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
+++ b/_events/202122-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
@@ -16,8 +16,7 @@ updated_at: 2020-12-04 18:57:48.000000000 Z
 **We will be doing this orientation virtually, please register here and
 we will make sure you get the link to join.**
 
-**\*\*NOTE: This Orientation is for <span style="text-decoration:
-underline;">Graduate Students and Postdocs </span>\*\***
+**\*\*NOTE: This Orientation is for <span>Graduate Students and Postdocs </span>\*\***
 
 Just arrived at the NIH? Wondering how to make the most of your time
 here? Want to set goals and establish expectations with your mentor?

--- a/_events/2021225-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
+++ b/_events/2021225-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
@@ -34,8 +34,8 @@ Kelly Donahue.  The discussion group provides a confidential and
 welcoming space to explore positive and proactive methods to build
 resilience and self-care skills with other trainees having similar
 experiences.  Even if you can\'t join us for the entire hour, we
-encourage you to still attend. <span style="font-size: 10pt;"> </span>
+encourage you to still attend. <span> </span>
 
-<span style="font-size: 10pt;"> </span>
+<span> </span>
 
  

--- a/_events/2021225-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch-celebrating-black-history-month.md
+++ b/_events/2021225-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch-celebrating-black-history-month.md
@@ -31,8 +31,8 @@ biography below. 
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">**Joanna Mountain, PhD**</span>  
-<span style="font-size: 8pt;"> <em>Senior Director of Research.
+<span>**Joanna Mountain, PhD**</span>
+<span> <em>Senior Director of Research.
 </em>Joanna Mountain is Senior Director of Research, where she is
 responsible for overseeing research projects, ensuring the protection of
 research participants, and developing approaches to evaluate and
@@ -42,8 +42,8 @@ and Genetics Departments at Stanford University. Joanna spent two years
 in Kenya as a Peace Corps volunteer and continues to be particularly
 interested in the genetic diversity of Africa.</span>
 
-<span style="font-size: 8pt;">**Steven Micheletti, PhD**</span>  
-<span style="font-size: 8pt;"> <em>Scientist II, Population Genetics.
+<span>**Steven Micheletti, PhD**</span>
+<span> <em>Scientist II, Population Genetics.
 </em>Steven is a Population Geneticist who works on Ancestry-related
 features and diversity initiatives. As an expert in using tools from
 genetics to study migrations, he also uses participant data to research
@@ -59,7 +59,7 @@ Washington State University (PhD).</span>
 
  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/2021226-md-and-md-phd-application-q-a-session.md
+++ b/_events/2021226-md-and-md-phd-application-q-a-session.md
@@ -12,19 +12,17 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-02-26 01:11:23.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, personal
 statement, AMCAS and MCAT updates, and other general questions. We are
 going to be meeting every other week. These sessions are not
 consecutive, so you can attend one or more, and as many as you
 want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/202123-scientists-teaching-science-90-minute-workshop-am-session.md
+++ b/_events/202123-scientists-teaching-science-90-minute-workshop-am-session.md
@@ -13,7 +13,7 @@ topic:
 - Teaching/Mentoring
 updated_at: 2021-02-01 21:40:10.000000000 Z
 ---
-<span style="font-size: 11.5052px;">Are you interested in learning the
+<span>Are you interested in learning the
 basics of successful teaching? Are you considering a career in
 education? If you answered \'yes\' to either of these questions then
 register for the OITE workshop \"Scientists Teaching Science: An

--- a/_events/202124-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
+++ b/_events/202124-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
@@ -15,14 +15,14 @@ topic:
 - Wellness
 updated_at: 2021-01-29 16:43:05.000000000 Z
 ---
-<span style="font-family: arial, helvetica, sans-serif;">This event is
+<span>This event is
 only for NIH Intramural Trainees currently in our postbac, graduate
 student, and postdoc programs.  This session will be held online via
 Zoom and the link will be distributed in NIH Trainee Listserv
 announcements. If you need the link immediately please email
 OITE@nih.gov. </span>
 
-<span style="font-family: arial, helvetica, sans-serif;">Mental health
+<span>Mental health
 conditions like anxiety, depression, OCD, ADHD/ADD,
 ASD sometimes occur as natural systems become dysregulated and they can
 often exacerbate each other. While experiencing the effects of anxiety
@@ -31,13 +31,13 @@ with these feelings. Come share your thoughts and learn from each
 other's experiences in dealing with anxiety, depression, and other
 challenges. </span>
 
-<span style="font-family: arial, helvetica, sans-serif;">Please join us
+<span>Please join us
 for an online discussion with OITE Wellness Advisor, Kelly Donahue.  The
 discussion group provides a confidential and welcoming space to explore
 positive and proactive methods to build resilience and self-care skills
 with other trainees having similar experiences.  Even if you can\'t join
 us for the entire hour, we encourage you to still attend.  </span>
 
-<span style="font-size: 10pt;"> </span>
+<span> </span>
 
  

--- a/_events/202124-discussion-for-building-resilience-international-trainees.md
+++ b/_events/202124-discussion-for-building-resilience-international-trainees.md
@@ -15,14 +15,14 @@ topic:
 - Wellness
 updated_at: 2021-01-29 16:45:06.000000000 Z
 ---
-<span style="font-family: arial, helvetica, sans-serif;">This event is
+<span>This event is
 only for NIH Intramural Trainees currently in our postbac, graduate
 student, and postdoc programs.  This session will be held online via
 Zoom and the link will be distributed in NIH Trainee Listserv
 announcements. If you need the link immediately please email
 OITE@nih.gov. </span>
 
-<span style="font-family: arial, helvetica, sans-serif;">International
+<span>International
 trainees often face a unique set of challenges. Whether it is the
 distance from family and home, learning a new culture, visa stress, or
 discovering a new sense of community, these challenges can cause fellows
@@ -33,7 +33,7 @@ are other trainees having similar experiences.  Additionally, the
 group offers space to dialogue around U.S. culture, coping tools and to
 learn from each other. </span>
 
-<span style="font-family: arial, helvetica, sans-serif;">Please join us
+<span>Please join us
 for a discussion with OITE Wellness Advisor, Emilie Gomart. The
 discussion group provides a welcoming and confidential space to explore
 positive and proactive ways to build resilience and self-care

--- a/_events/202124-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
+++ b/_events/202124-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
@@ -31,7 +31,7 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/202125-discussion-for-building-resilience-addictive-behaviors.md
+++ b/_events/202125-discussion-for-building-resilience-addictive-behaviors.md
@@ -15,15 +15,13 @@ topic:
 - Wellness
 updated_at: 2021-01-29 16:47:11.000000000 Z
 ---
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">This event is only for NIH Intramural Trainees currently in our
+<span>This event is only for NIH Intramural Trainees currently in our
 postbac, graduate student, and postdoc programs.  This session will be
 held online via Zoom and the link will be distributed in NIH Trainee
 Listserv announcements. If you need the link immediately please email
 OITE@nih.gov. </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Habits are hard to break and when we are faced with a monumental
+<span>Habits are hard to break and when we are faced with a monumental
 shift in our day to day lives, isolation from whom and what we love, and
 fear about the future, we are likely to rely on habits even more than
 usual.  If you are struggling to make sense of your own addictive
@@ -33,8 +31,7 @@ with some compassionate support, you can gain the tools you need to
 develop a happier and healthier you and thrive in our new version of
 normal. </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Please join us for an online discussion with OITE Wellness
+<span>Please join us for an online discussion with OITE Wellness
 Advisor, Marin Rieger.   Building your resiliency and self-care skills
 now will help you to successfully navigate through periods of growth,
 and will serve you well throughout your academic and career path.  Even

--- a/_events/202128-discussion-for-building-resilience-trainees-of-color.md
+++ b/_events/202128-discussion-for-building-resilience-trainees-of-color.md
@@ -15,15 +15,13 @@ topic:
 - Wellness
 updated_at: 2021-01-28 00:29:18.000000000 Z
 ---
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">This event is only for NIH Intramural Trainees currently in our
+<span>This event is only for NIH Intramural Trainees currently in our
 postbac, graduate student, and postdoc programs.  This session will be
 held online via Zoom and the link will be distributed in NIH Trainee
 Listserv announcements. If you need the link immediately please email
 OITE@nih.gov. </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">The trainee of color discussion group offers a warm and
+<span>The trainee of color discussion group offers a warm and
 welcoming environment for trainees of color to engage in a safe
 space. Through the sharing of unique challenges and experiences,
 building community, and celebrating difference this group helps trainees
@@ -32,8 +30,7 @@ feeling isolated, are unsure, or just want to expand your community,
 this group is for you.  This session is open to trainees at all
 levels.  </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Please join us for a discussion with OITE Wellness Advisor, Jenn
+<span>Please join us for a discussion with OITE Wellness Advisor, Jenn
 Wiggins. The discussion group provides a welcoming and confidential
 space to explore positive and proactive ways to build resilience and
 self-care skills.</span>

--- a/_events/202129-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
+++ b/_events/202129-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
@@ -15,14 +15,14 @@ topic:
 - Wellness
 updated_at: 2021-01-29 16:49:45.000000000 Z
 ---
-<span style="font-family: arial, helvetica, sans-serif;">This event is
+<span>This event is
 only for NIH Intramural Trainees currently in our postbac, graduate
 student, and postdoc programs.  This session will be held online via
 Zoom and the link will be distributed in NIH Trainee Listserv
 announcements. If you need the link immediately please email
 OITE@nih.gov. </span>
 
-<span style="font-family: arial, helvetica, sans-serif;">Mental health
+<span>Mental health
 conditions like anxiety, depression, OCD, ADHD/ADD,
 ASD sometimes occur as natural systems become dysregulated and they can
 often exacerbate each other. While experiencing the effects of anxiety
@@ -31,7 +31,7 @@ with these feelings. Come share your thoughts and learn from each
 other's experiences in dealing with anxiety, depression, and other
 challenges. </span>
 
-<span style="font-family: arial, helvetica, sans-serif;">Please join us
+<span>Please join us
 for an online discussion with OITE Wellness Advisor, Annie Scheiner.
  The discussion group provides a confidential and welcoming space to
 explore positive and proactive methods to build resilience and self-care
@@ -39,6 +39,6 @@ skills with other trainees having similar experiences.  Even if you
 can\'t join us for the entire hour, we encourage you to still
 attend.  </span>
 
-<span style="font-size: 10pt;"> </span>
+<span> </span>
 
  

--- a/_events/2021311-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
+++ b/_events/2021311-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
@@ -31,7 +31,7 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/2021312-md-and-md-phd-application-q-a-session.md
+++ b/_events/2021312-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-02-13 00:23:04.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/2021318-discussion-for-building-resilience-lgbtqia-trainees.md
+++ b/_events/2021318-discussion-for-building-resilience-lgbtqia-trainees.md
@@ -37,8 +37,7 @@ space to explore positive and proactive ways to build resilience and
 self-care skills. Even if you can\'t join us for the entire hour, we
 encourage you to still attend. 
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;"> </span>
+<span> </span>
 
  
 

--- a/_events/2021318-discussion-for-building-resilience-self-compassion-for-trainees.md
+++ b/_events/2021318-discussion-for-building-resilience-self-compassion-for-trainees.md
@@ -36,8 +36,7 @@ confidential space to explore positive and proactive ways to build
 resilience and self-care skills. Even if you can\'t join us for the
 entire hour, we encourage you to still attend.  
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;"> </span>
+<span> </span>
 
  
 

--- a/_events/2021318-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch-cultural-competency-in-science-communication.md
+++ b/_events/2021318-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch-cultural-competency-in-science-communication.md
@@ -35,9 +35,9 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="text-decoration: underline;">Speakers Biography</span>
+<span>Speakers Biography</span>
 
-<span style="font-size: 8pt;"><strong>Dr. Asher Williams </strong>is
+<span><strong>Dr. Asher Williams </strong>is
 currently a Presidential Postdoctoral Fellow at Cornell University where
 her research is aimed at cell-free biosynthesis of conjugate vaccines
 against emerging pathogens. She is also a part of a global team of
@@ -56,7 +56,7 @@ was named an RPI Class of 2020 Changemaker and is listed as one of 1000
 Inspiring Black Scientists in America and a 2020 MIT Rising Star in
 Chemical Engineering.</span>
 
-<span style="font-size: 8pt;">**Dr. Laura Lindenfeld **is the Executive
+<span>**Dr. Laura Lindenfeld **is the Executive
 Director of the Alda Center, Dean of the School of Communication and
 Journalism, and Vice Provost for Academic Strategy and Planning, and a
 professor of journalism. She holds a PhD in cultural studies from the
@@ -80,7 +80,7 @@ communication. Her work seeks to understand how we can support effective
 stakeholder engagement and communicate science more effectively and
 persuasively. </span>
 
-<span style="font-size: 8pt;">**Dr. Kelly Gonzales**, a citizen of the
+<span>**Dr. Kelly Gonzales**, a citizen of the
 Cherokee Nation of Oklahoma, is an associate professor at Oregon Health
 &amp; Science University and Portland State University. Dr. Gonzalez
 studies health disparities, particularly those related to diabetes among
@@ -91,7 +91,7 @@ Authority's COVID-19 Vaccine Advisory Council to provide guidance on
 Oregon's vaccine distribution plan, including vaccine sequencing for
 phases 1b, 1c and 2 of the state's vaccine distribution plan.</span>
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/2021319-workplace-dynamics-iv-team-skills.md
+++ b/_events/2021319-workplace-dynamics-iv-team-skills.md
@@ -15,7 +15,7 @@ topic:
 - Personal Development
 updated_at: 2020-12-11 21:35:17.000000000 Z
 ---
-<span style="font-size: 12px;">ONLINE
+<span>ONLINE
 ONLY-[https://attendee.gotowebinar.com/register/8599383106991652111][1]{:
 #share-reg-url .plAwLUVihzEw9Kyd target="_blank" rel="noopener
 noreferrer"}</span>

--- a/_events/202132-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
+++ b/_events/202132-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
@@ -16,8 +16,7 @@ updated_at: 2020-12-04 18:59:40.000000000 Z
 **We will be doing this orientation virtually, please register here and
 we will make sure you get the link to join.**
 
-**\*\*NOTE: This Orientation is for <span style="text-decoration:
-underline;">Graduate Students and Postdocs </span>\*\***
+**\*\*NOTE: This Orientation is for <span>Graduate Students and Postdocs </span>\*\***
 
 Just arrived at the NIH? Wondering how to make the most of your time
 here? Want to set goals and establish expectations with your mentor?

--- a/_events/2021325-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
+++ b/_events/2021325-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
@@ -36,6 +36,6 @@ resilience and self-care skills with other trainees having similar
 experiences.  Even if you can\'t join us for the entire hour, we
 encourage you to still attend.  
 
-<span style="font-size: 10pt;"> </span>
+<span> </span>
 
  

--- a/_events/2021325-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
+++ b/_events/2021325-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
@@ -31,7 +31,7 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/2021326-md-and-md-phd-application-q-a-session.md
+++ b/_events/2021326-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-02-13 00:23:36.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/202133-felcom-event-scientific-administration-in-academia-and-government.md
+++ b/_events/202133-felcom-event-scientific-administration-in-academia-and-government.md
@@ -26,9 +26,9 @@ also  be available for a question answer session. Come and join us to
 learn more about those fascinating careers and get tips for making
 successful career transition!
 
-<span style="font-size: 12px;">This event is sponsored by Felcom.</span>
+<span>This event is sponsored by Felcom.</span>
 
-<span style="font-size: 12px;">Register via
+<span>Register via
 zoom: https://nih.zoomgov.com/meeting/register/vJItcOuoqTMsHXLSbYgy3CUtsyixhdT1B\_Q</span>
 
  

--- a/_events/2021331-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
+++ b/_events/2021331-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
@@ -31,7 +31,7 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/202134-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
+++ b/_events/202134-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
@@ -31,7 +31,7 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/2021412-the-academic-job-search-evaluating-positions-and-negotiating-offers.md
+++ b/_events/2021412-the-academic-job-search-evaluating-positions-and-negotiating-offers.md
@@ -14,8 +14,7 @@ topic:
 - Job Search Skills
 updated_at: 2021-04-12 19:46:36.000000000 Z
 ---
-<span style="font-size: 11.5051517486572px; line-height:
-17.8329830169678px;">So you\'ve got the job offer! Now what do you do?
+<span>So you\'ve got the job offer! Now what do you do?
 In this workshop, learn what you should consider when beginning
 negotiations. Also, learn what you can and cannot negotiate and hear
 strategies for clearly articulating your wants and needs.</span>

--- a/_events/2021414-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-monthly-event-md-do-md-phd-panel-on-admissions-diversity.md
+++ b/_events/2021414-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-monthly-event-md-do-md-phd-panel-on-admissions-diversity.md
@@ -36,7 +36,7 @@ noreferrer"}.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/2021415-discussion-for-building-resilience-lgbtqia-trainees.md
+++ b/_events/2021415-discussion-for-building-resilience-lgbtqia-trainees.md
@@ -37,8 +37,7 @@ confidential space to explore positive and proactive ways to build
 resilience and self-care skills. Even if you can\'t join us for the
 entire hour, we encourage you to still attend. 
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;"> </span>
+<span> </span>
 
  
 

--- a/_events/2021415-discussion-for-building-resilience-self-compassion-for-trainees.md
+++ b/_events/2021415-discussion-for-building-resilience-self-compassion-for-trainees.md
@@ -15,14 +15,12 @@ topic:
 - Wellness
 updated_at: 2021-03-30 15:04:13.000000000 Z
 ---
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">This session is only for NIH Intramural Trainees.  This online
+<span>This session is only for NIH Intramural Trainees.  This online
 session will be held with Zoom.  The meeting link will be distributed
 via the NIH Trainee Listservs. If you need the link immediately please
 email OITE@nih.gov.</span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Most of us spend more time in our heads or talking to ourselves
+<span>Most of us spend more time in our heads or talking to ourselves
 than we will ever spend talking with others. Would you say to others, a
 good friend for example, the types of things you say to yourself? Using
 the principles of self-compassion, we'll examine how the messaging we
@@ -32,15 +30,13 @@ understanding that is rooted in kindness for us and those around us.
 Join our conversation as we explore opportunities to understand what
 self-compassion is and how you can put it to work for you! </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;">Please join us for an online discussion with OITE Wellness
+<span>Please join us for an online discussion with OITE Wellness
 Advisor, Fabian Drain.  The discussion group provides a welcoming and
 confidential space to explore positive and proactive ways to build
 resilience and self-care skills. Even if you can\'t join us for the
 entire hour, we encourage you to still attend.  </span>
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;"> </span>
+<span> </span>
 
  
 

--- a/_events/2021422-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
+++ b/_events/2021422-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
@@ -36,6 +36,6 @@ resilience and self-care skills with other trainees having similar
 experiences.  Even if you can\'t join us for the entire hour, we
 encourage you to still attend.  
 
-<span style="font-size: 10pt;"> </span>
+<span> </span>
 
  

--- a/_events/2021423-md-and-md-phd-application-q-a-session.md
+++ b/_events/2021423-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-02-13 00:24:36.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/202146-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
+++ b/_events/202146-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
@@ -36,6 +36,6 @@ resilience and self-care skills with other trainees having similar
 experiences.  Even if you can\'t join us for the entire hour, we
 encourage you to still attend.  
 
-<span style="font-size: 10pt;"> </span>
+<span> </span>
 
  

--- a/_events/202146-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
+++ b/_events/202146-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
@@ -16,8 +16,7 @@ updated_at: 2020-12-04 19:01:40.000000000 Z
 **We will be doing this orientation virtually, please register here and
 we will make sure you get the link to join.**
 
-**\*\*NOTE: This Orientation is for <span style="text-decoration:
-underline;">Graduate Students and Postdocs </span>\*\***
+**\*\*NOTE: This Orientation is for <span>Graduate Students and Postdocs </span>\*\***
 
 Just arrived at the NIH? Wondering how to make the most of your time
 here? Want to set goals and establish expectations with your mentor?

--- a/_events/202149-md-and-md-phd-application-q-a-session.md
+++ b/_events/202149-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-02-13 00:24:11.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/2021511-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
+++ b/_events/2021511-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
@@ -16,8 +16,7 @@ updated_at: 2021-05-11 15:53:32.000000000 Z
 **We will be doing this orientation virtually, please register here and
 we will make sure you get the link to join.**
 
-**\*\*NOTE: This Orientation is for <span style="text-decoration:
-underline;">Graduate Students and Postdocs </span>\*\***
+**\*\*NOTE: This Orientation is for <span>Graduate Students and Postdocs </span>\*\***
 
 Just arrived at the NIH? Wondering how to make the most of your time
 here? Want to set goals and establish expectations with your mentor?

--- a/_events/2021512-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
+++ b/_events/2021512-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
@@ -31,7 +31,7 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/2021520-discussion-for-building-resilience-lgbtqia-trainees.md
+++ b/_events/2021520-discussion-for-building-resilience-lgbtqia-trainees.md
@@ -37,8 +37,7 @@ confidential space to explore positive and proactive ways to build
 resilience and self-care skills. Even if you can\'t join us for the
 entire hour, we encourage you to still attend. 
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;"> </span>
+<span> </span>
 
  
 

--- a/_events/2021521-md-and-md-phd-application-q-a-session.md
+++ b/_events/2021521-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-02-13 00:25:36.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/2021526-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch-racism-minority-mistrust-with-research-institutions-what-should-we-do.md
+++ b/_events/2021526-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch-racism-minority-mistrust-with-research-institutions-what-should-we-do.md
@@ -33,8 +33,7 @@ historically neglected.
 
 Speaker\'s Biographies: 
 
-<span style="font-size: 8pt;"><span style="text-decoration:
-underline;">Ms. Nicole Coco Villaluz</span>
+<span><span>Ms. Nicole Coco Villaluz</span>
 (Hidatsa/Assiniboine/Chamorro), the Director of Health Equity Programs
 at ClearWay Minnesota. She has over eighteen years of experience in all
 phases of community development, capacity building and mobilizing. CoCo
@@ -48,8 +47,7 @@ her home community. She is also the recipient of the Minnesota Public
 Health Association's Paul and Sheila Wellstone Public Health Achievement
 Award for 2020.</span>
 
-<span style="font-size: 8pt;"><span style="text-decoration:
-underline;">Dr. Kelvin Choi,</span> PhD, MPH, is a Senior Investigator
+<span><span>Dr. Kelvin Choi,</span> PhD, MPH, is a Senior Investigator
 and Head of the Social and Behavioral Sciences Section at the Division
 of Intramural Research, National Institute on Minority Health and Health
 Disparities (NIMHD). He was recruited to the NIH as an Earl Stadtman
@@ -83,7 +81,7 @@ event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/2021527-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
+++ b/_events/2021527-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
@@ -36,6 +36,6 @@ resilience and self-care skills with other trainees having similar
 experiences.  Even if you can\'t join us for the entire hour, we
 encourage you to still attend.  
 
-<span style="font-size: 10pt;"> </span>
+<span> </span>
 
  

--- a/_events/2021528-md-and-md-phd-application-q-a-session.md
+++ b/_events/2021528-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-05-27 20:14:00.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/202157-md-and-md-phd-application-q-a-session.md
+++ b/_events/202157-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-02-13 00:25:05.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/202161-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
+++ b/_events/202161-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
@@ -16,8 +16,7 @@ updated_at: 2021-05-12 16:55:32.000000000 Z
 **We will be doing this orientation virtually, please register here and
 we will make sure you get the link to join.**
 
-**\*\*NOTE: This Orientation is for <span style="text-decoration:
-underline;">Graduate Students and Postdocs </span>\*\***
+**\*\*NOTE: This Orientation is for <span>Graduate Students and Postdocs </span>\*\***
 
 Just arrived at the NIH? Wondering how to make the most of your time
 here? Want to set goals and establish expectations with your mentor?

--- a/_events/2021615-becoming-a-resilient-scientist-series-ii-exploring-our-self-talk-cognitive-distortions-and-imposter-fears.md
+++ b/_events/2021615-becoming-a-resilient-scientist-series-ii-exploring-our-self-talk-cognitive-distortions-and-imposter-fears.md
@@ -50,12 +50,12 @@ for high school students and recent high school graduates (July 8-27).
 Each series will consist of four workshops and four small group
 discussions:
 
-| <span style="color: #003300;">**For Students in College and Above**</span> | <span style="color: #003300;">**Workshop**</span> | <span style="color: #003300;">**Group Discussion**</span> |
+| <span>**Group Discussion**</span> |
 | Week 1 - I. An Introduction to Resilience and Wellness | 6/8/2021 | 6/10/2021 |
 | Week 2 - II. Exploring Our Self-Talk: Cognitive Distortions and Imposter Fears | 6/15/2021 | 6/17/2021 |
 | Week 3 - III. Self-Advocacy and Assertiveness | 6/22/2021 | 6/24/2021 |
 | Week 4 - IV. Feedback Resilience | 6/29/2021 | 7/1/2021 |
-| <span style="color: #003300;">**For High School Students and Recent Graduates**</span> | <span style="color: #003300;">**Workshop**</span> | <span style="color: #003300;">**Group Discussion**</span> |
+| <span>**Group Discussion**</span> |
 | Week 1 - I. An Introduction to Resilience and Wellness | 7/6/2021 | 7/8/2021 |
 | Week 2 - II. Exploring Our Self-Talk: Cognitive Distortions and Imposter Fears | 7/13/2021 | 7/15/2021 |
 | Week 3 - III. Self-Advocacy and Assertiveness | 7/20/2021 | 7/22/2021 |

--- a/_events/2021615-summer-lecture-series-i-the-transcreation-framework-translating-behavioral-interventions-to-reduce-health-disparities-dr-anna-maria-napoles.md
+++ b/_events/2021615-summer-lecture-series-i-the-transcreation-framework-translating-behavioral-interventions-to-reduce-health-disparities-dr-anna-maria-napoles.md
@@ -18,12 +18,12 @@ updated_at: 2021-05-21 23:00:30.000000000 Z
 ---
 <!--StartFragment-->
 
-<span style="color: #262626;"><span style="font-size: 100%;">First in
+<span>First in
 the series of lectures specifically arranged for trainees in the NIH
 Summer Internship Program.</span></span>
 {: .MsoNormal}
 
-<span style="color: #262626;"><span style="font-size: 100%;">**Event
+<span>**Event
 Link: **[https://nih.zoomgov.com/webinar/register/WN\_35ffLcIeQ-mLGUh6eYliTg][1]
 
 </span></span>

--- a/_events/2021617-discussion-for-building-resilience-lgbtqia-trainees.md
+++ b/_events/2021617-discussion-for-building-resilience-lgbtqia-trainees.md
@@ -37,8 +37,7 @@ confidential space to explore positive and proactive ways to build
 resilience and self-care skills. Even if you can\'t join us for the
 entire hour, we encourage you to still attend. 
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;"> </span>
+<span> </span>
 
  
 

--- a/_events/2021617-essential-leadership-skills-for-future-scientists-and-health-care-professionals.md
+++ b/_events/2021617-essential-leadership-skills-for-future-scientists-and-health-care-professionals.md
@@ -25,7 +25,7 @@ yourself and how you relate to others. Good communication skills.
 Developing yourself as a leader without power. This session is
 specifically for scientists at the undergraduate level.
 
-<span style="color: #ff0000;">** **</span>
+<span>** **</span>
 
 
 

--- a/_events/2021618-cancelled-planning-a-successful-nih-summer-internship.md
+++ b/_events/2021618-cancelled-planning-a-successful-nih-summer-internship.md
@@ -12,7 +12,7 @@ topic:
 - Orientation
 updated_at: 2021-06-18 15:43:06.000000000 Z
 ---
-<span style="color: #800000;">**CANCELLED: In recognition of
+<span>**CANCELLED: In recognition of
 Juneteenth, "Planning a Successful NIH Summer Internship" scheduled for
 June 18, 2021 is cancelled.  We look forward to seeing you at the next
 one (June 25, 2021).**</span>

--- a/_events/2021622-becoming-a-resilient-scientist-series-iii-self-advocacy-and-assertiveness.md
+++ b/_events/2021622-becoming-a-resilient-scientist-series-iii-self-advocacy-and-assertiveness.md
@@ -48,12 +48,12 @@ for high school students and recent high school graduates (July 8-27).
 Each series will consist of four workshops and four small group
 discussions:
 
-| <span style="color: #003300;">**For Students in College and Above**</span> | <span style="color: #003300;">**Workshop**</span> | <span style="color: #003300;">**Group Discussion**</span> |
+| <span>**Group Discussion**</span> |
 | Week 1 - I. An Introduction to Resilience and Wellness | 6/8/2021 | 6/10/2021 |
 | Week 2 - II. Exploring Our Self-Talk: Cognitive Distortions and Imposter Fears | 6/15/2021 | 6/17/2021 |
 | Week 3 - III. Self-Advocacy and Assertiveness | 6/22/2021 | 6/24/2021 |
 | Week 4 - IV. Feedback Resilience | 6/29/2021 | 7/1/2021 |
-| <span style="color: #003300;">**For High School Students and Recent Graduates**</span> | <span style="color: #003300;">**Workshop**</span> | <span style="color: #003300;">**Group Discussion**</span> |
+| <span>**Group Discussion**</span> |
 | Week 1 - I. An Introduction to Resilience and Wellness | 7/6/2021 | 7/8/2021 |
 | Week 2 - II. Exploring Our Self-Talk: Cognitive Distortions and Imposter Fears | 7/13/2021 | 7/15/2021 |
 | Week 3 - III. Self-Advocacy and Assertiveness | 7/20/2021 | 7/22/2021 |

--- a/_events/2021623-choosing-and-applying-to-medical-school.md
+++ b/_events/2021623-choosing-and-applying-to-medical-school.md
@@ -22,8 +22,7 @@ the application, asking for references, and developing your timeline.
 
 [Resources for Pre-Med][2]
 
-[Identifying Medical Schools for Your AMCAS Application][3]{:
-style="font-size: 11.5052px;"}
+[Identifying Medical Schools for Your AMCAS Application][3]
 
  
 

--- a/_events/2021623-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
+++ b/_events/2021623-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
@@ -31,7 +31,7 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/2021625-md-and-md-phd-application-q-a-session.md
+++ b/_events/2021625-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-06-23 00:36:00.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/2021629-becoming-a-resilient-scientist-series-iv-feedback-resilience-now-at-2-30pm.md
+++ b/_events/2021629-becoming-a-resilient-scientist-series-iv-feedback-resilience-now-at-2-30pm.md
@@ -50,12 +50,12 @@ for high school students and recent high school graduates (July 8-27).
 Each series will consist of four workshops and four small group
 discussions:
 
-| <span style="color: #003300;">**For Students in College and Above**</span> | <span style="color: #003300;">**Workshop**</span> | <span style="color: #003300;">**Group Discussion**</span> |
+| <span>**Group Discussion**</span> |
 | Week 1 - I. An Introduction to Resilience and Wellness | 6/8/2021 | 6/10/2021 |
 | Week 2 - II. Exploring Our Self-Talk: Cognitive Distortions and Imposter Fears | 6/15/2021 | 6/17/2021 |
 | Week 3 - III. Self-Advocacy and Assertiveness | 6/22/2021 | 6/24/2021 |
 | Week 4 - IV. Feedback Resilience | 6/29/2021 | 7/1/2021 |
-| <span style="color: #003300;">**For High School Students and Recent Graduates**</span> | <span style="color: #003300;">**Workshop**</span> | <span style="color: #003300;">**Group Discussion**</span> |
+| <span>**Group Discussion**</span> |
 | Week 1 - I. An Introduction to Resilience and Wellness | 7/6/2021 | 7/8/2021 |
 | Week 2 - II. Exploring Our Self-Talk: Cognitive Distortions and Imposter Fears | 7/13/2021 | 7/15/2021 |
 | Week 3 - III. Self-Advocacy and Assertiveness | 7/20/2021 | 7/22/2021 |

--- a/_events/2021629-summer-lecture-series-ii-meet-the-person-behind-the-title-dr-francis-collins-nih-director.md
+++ b/_events/2021629-summer-lecture-series-ii-meet-the-person-behind-the-title-dr-francis-collins-nih-director.md
@@ -18,7 +18,7 @@ updated_at: 2021-06-25 17:17:13.000000000 Z
 ---
 <!--StartFragment-->
 
-<span style="color: #262626;"><span style="font-size: 100%;">Second in
+<span>Second in
 the series of lectures specifically arranged for trainees in the NIH
 Summer Internship Program.</span></span>
 {: .MsoNormal}
@@ -34,14 +34,13 @@ mission. Dr. Collins will give a short presentation and will then
 respond to questions submitted by trainees who register for the webinar
 in advance.
 
-<span style="color: #262626;"><span style="font-size: 100%;">Event
+<span>Event
 Link: [https://nih.zoomgov.com/webinar/register/WN\_RIoCdTKeRSqbyUPDNAudmA][1]</span></span>
 {: .MsoNormal}
 
-<span style="font-size: 11px;">For more information about the speaker,
+<span>For more information about the speaker,
 please visit this website:
-</span>[https://www.nih.gov/about-nih/who-we-are/nih-director/biographical-sketch-francis-s-collins-md-phd][2]{:
-style="font-size: 11px;"}
+</span>[https://www.nih.gov/about-nih/who-we-are/nih-director/biographical-sketch-francis-s-collins-md-phd][2]
 {: .MsoNormal}
 
  

--- a/_events/202164-md-and-md-phd-application-q-a-session.md
+++ b/_events/202164-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-05-27 20:21:18.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/202168-becoming-a-resilient-scientist-series-i-an-introduction-to-resilience-and-wellness.md
+++ b/_events/202168-becoming-a-resilient-scientist-series-i-an-introduction-to-resilience-and-wellness.md
@@ -47,12 +47,12 @@ for high school students and recent high school graduates (July 8-27).
 Each series will consist of four workshops and four small group
 discussions:
 
-| <span style="color: #003300;">**For Students in College and Above**</span> | <span style="color: #003300;">**Workshop**</span> | <span style="color: #003300;">**Group Discussion**</span> |
+| <span>**Group Discussion**</span> |
 | Week 1 - I. An Introduction to Resilience and Wellness | 6/8/2021 | 6/10/2021 |
 | Week 2 - II. Exploring Our Self-Talk: Cognitive Distortions and Imposter Fears | 6/15/2021 | 6/17/2021 |
 | Week 3 - III. Self-Advocacy and Assertiveness | 6/22/2021 | 6/24/2021 |
 | Week 4 - IV. Feedback Resilience | 6/29/2021 | 7/1/2021 |
-| <span style="color: #003300;">**For High School Students and Recent Graduates**</span> | <span style="color: #003300;">**Workshop**</span> | <span style="color: #003300;">**Group Discussion**</span> |
+| <span>**Group Discussion**</span> |
 | Week 1 - I. An Introduction to Resilience and Wellness | 7/6/2021 | 7/8/2021 |
 | Week 2 - II. Exploring Our Self-Talk: Cognitive Distortions and Imposter Fears | 7/13/2021 | 7/15/2021 |
 | Week 3 - III. Self-Advocacy and Assertiveness | 7/20/2021 | 7/22/2021 |

--- a/_events/202169-cancelled-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch-nourish-to-flourish-a-self-care-workshop-on-avoiding-burnout.md
+++ b/_events/202169-cancelled-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch-nourish-to-flourish-a-self-care-workshop-on-avoiding-burnout.md
@@ -46,7 +46,7 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/202171-ethics-in-research-environments-for-summer-students.md
+++ b/_events/202171-ethics-in-research-environments-for-summer-students.md
@@ -13,15 +13,15 @@ topic:
 - Ethics, Responsible Conduct of Research
 updated_at: 2021-05-13 00:01:15.000000000 Z
 ---
-<span style="font-size: 11.5052px;">Event
+<span>Event
 Link: [https://attendee.gotowebinar.com/register/4212632981697587981][1]</span>
 
-<span style="font-size: 11.5052px;">**NOTE: This workshop is part of
+<span>**NOTE: This workshop is part of
 Virtual Summer Enrichment Curriculum; the target audience is NIH summer
 interns and students outside NIH. NIH Postbacs, Graduate students, and
 postdocs will NOT receive credit for this course.**</span>
 
-<span style="font-size: 11.5052px;">Research Ethics is at the foundation
+<span>Research Ethics is at the foundation
 of everything we do in the scientific endeavor, and training in
 Responsible Conduct of Research is an essential component of your
 development as a scientist as you train here at the NIH. The news is

--- a/_events/2021713-hs-sip-becoming-a-resilient-scientist-series-ii-exploring-our-self-talk-cognitive-distortions-and-imposter-fears.md
+++ b/_events/2021713-hs-sip-becoming-a-resilient-scientist-series-ii-exploring-our-self-talk-cognitive-distortions-and-imposter-fears.md
@@ -50,12 +50,12 @@ for high school students and recent high school graduates (July 8-27).
 Each series will consist of four workshops and four small group
 discussions:
 
-| <span style="color: #003300;">**For Students in College and Above**</span> | <span style="color: #003300;">**Workshop**</span> | <span style="color: #003300;">**Group Discussion**</span> |
+| <span>**Group Discussion**</span> |
 | Week 1 - I. An Introduction to Resilience and Wellness | 6/8/2021 | 6/10/2021 |
 | Week 2 - II. Exploring Our Self-Talk: Cognitive Distortions and Imposter Fears | 6/15/2021 | 6/17/2021 |
 | Week 3 - III. Self-Advocacy and Assertiveness | 6/22/2021 | 6/24/2021 |
 | Week 4 - IV. Feedback Resilience | 6/29/2021 | 7/1/2021 |
-| <span style="color: #003300;">**For High School Students and Recent Graduates**</span> | <span style="color: #003300;">**Workshop**</span> | <span style="color: #003300;">**Group Discussion**</span> |
+| <span>**Group Discussion**</span> |
 | Week 1 - I. An Introduction to Resilience and Wellness | 7/6/2021 | 7/8/2021 |
 | Week 2 - II. Exploring Our Self-Talk: Cognitive Distortions and Imposter Fears | 7/13/2021 | 7/15/2021 |
 | Week 3 - III. Self-Advocacy and Assertiveness | 7/20/2021 | 7/22/2021 |

--- a/_events/2021715-discussion-for-building-resilience-lgbtqia-trainees.md
+++ b/_events/2021715-discussion-for-building-resilience-lgbtqia-trainees.md
@@ -37,8 +37,7 @@ confidential space to explore positive and proactive ways to build
 resilience and self-care skills. Even if you can\'t join us for the
 entire hour, we encourage you to still attend. 
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;"> </span>
+<span> </span>
 
  
 

--- a/_events/2021716-md-and-md-phd-application-q-a-session.md
+++ b/_events/2021716-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-06-23 15:41:09.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/202172-md-and-md-phd-application-q-a-session.md
+++ b/_events/202172-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-06-23 15:40:36.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/2021720-hs-sip-becoming-a-resilient-scientist-series-iii-self-advocacy-and-assertiveness.md
+++ b/_events/2021720-hs-sip-becoming-a-resilient-scientist-series-iii-self-advocacy-and-assertiveness.md
@@ -48,12 +48,12 @@ for high school students and recent high school graduates (July 8-27).
 Each series will consist of four workshops and four small group
 discussions:
 
-| <span style="color: #003300;">**For Students in College and Above**</span> | <span style="color: #003300;">**Workshop**</span> | <span style="color: #003300;">**Group Discussion**</span> |
+| <span>**Group Discussion**</span> |
 | Week 1 - I. An Introduction to Resilience and Wellness | 6/8/2021 | 6/10/2021 |
 | Week 2 - II. Exploring Our Self-Talk: Cognitive Distortions and Imposter Fears | 6/15/2021 | 6/17/2021 |
 | Week 3 - III. Self-Advocacy and Assertiveness | 6/22/2021 | 6/24/2021 |
 | Week 4 - IV. Feedback Resilience | 6/29/2021 | 7/1/2021 |
-| <span style="color: #003300;">**For High School Students and Recent Graduates**</span> | <span style="color: #003300;">**Workshop**</span> | <span style="color: #003300;">**Group Discussion**</span> |
+| <span>**Group Discussion**</span> |
 | Week 1 - I. An Introduction to Resilience and Wellness | 7/6/2021 | 7/8/2021 |
 | Week 2 - II. Exploring Our Self-Talk: Cognitive Distortions and Imposter Fears | 7/13/2021 | 7/15/2021 |
 | Week 3 - III. Self-Advocacy and Assertiveness | 7/20/2021 | 7/22/2021 |

--- a/_events/2021727-hs-sip-becoming-a-resilient-scientist-series-iv-feedback-resilience.md
+++ b/_events/2021727-hs-sip-becoming-a-resilient-scientist-series-iv-feedback-resilience.md
@@ -48,12 +48,12 @@ for high school students and recent high school graduates (July 8-27).
 Each series will consist of four workshops and four small group
 discussions:
 
-| <span style="color: #003300;">**For Students in College and Above**</span> | <span style="color: #003300;">**Workshop**</span> | <span style="color: #003300;">**Group Discussion\***</span> |
+| <span>**Group Discussion\***</span> |
 | Week 1 - I. An Introduction to Resilience and Wellness | 6/8/2021 | 6/10/2021 |
 | Week 2 - II. Exploring Our Self-Talk: Cognitive Distortions and Imposter Fears | 6/15/2021 | 6/17/2021 |
 | Week 3 - III. Self-Advocacy and Assertiveness | 6/22/2021 | 6/24/2021 |
 | Week 4 - IV. Feedback Resilience | 6/29/2021 | 7/1/2021 |
-| <span style="color: #003300;">**For High School Students and Recent Graduates**</span> | <span style="color: #003300;">**Workshop**</span> | <span style="color: #003300;">**Group Discussion\***</span> |
+| <span>**Group Discussion\***</span> |
 | Week 1 - I. An Introduction to Resilience and Wellness | 7/6/2021 | 7/8/2021 |
 | Week 2 - II. Exploring Our Self-Talk: Cognitive Distortions and Imposter Fears | 7/13/2021 | 7/15/2021 |
 | Week 3 - III. Self-Advocacy and Assertiveness | 7/20/2021 | 7/22/2021 |

--- a/_events/2021728-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
+++ b/_events/2021728-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch.md
@@ -31,7 +31,7 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/2021729-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
+++ b/_events/2021729-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
@@ -36,6 +36,6 @@ resilience and self-care skills with other trainees having similar
 experiences.  Even if you can\'t join us for the entire hour, we
 encourage you to still attend.  
 
-<span style="font-size: 10pt;"> </span>
+<span> </span>
 
  

--- a/_events/2021730-md-and-md-phd-application-q-a-session-this-week-at-1-00-pm.md
+++ b/_events/2021730-md-and-md-phd-application-q-a-session-this-week-at-1-00-pm.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-07-23 17:10:59.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/202176-hs-sip-becoming-a-resilient-scientist-series-i-an-introduction-to-resilience-and-wellness.md
+++ b/_events/202176-hs-sip-becoming-a-resilient-scientist-series-i-an-introduction-to-resilience-and-wellness.md
@@ -47,12 +47,12 @@ for high school students and recent high school graduates (July 8-27).
 Each series will consist of four workshops and four small group
 discussions:
 
-| <span style="color: #003300;">**For Students in College and Above**</span> | <span style="color: #003300;">**Workshop**</span> | <span style="color: #003300;">**Group Discussion**</span> |
+| <span>**Group Discussion**</span> |
 | Week 1 - I. An Introduction to Resilience and Wellness | 6/8/2021 | 6/10/2021 |
 | Week 2 - II. Exploring Our Self-Talk: Cognitive Distortions and Imposter Fears | 6/15/2021 | 6/17/2021 |
 | Week 3 - III. Self-Advocacy and Assertiveness | 6/22/2021 | 6/24/2021 |
 | Week 4 - IV. Feedback Resilience | 6/29/2021 | 7/1/2021 |
-| <span style="color: #003300;">**For High School Students and Recent Graduates**</span> | <span style="color: #003300;">**Workshop**</span> | <span style="color: #003300;">**Group Discussion**</span> |
+| <span>**Group Discussion**</span> |
 | Week 1 - I. An Introduction to Resilience and Wellness | 7/6/2021 | 7/8/2021 |
 | Week 2 - II. Exploring Our Self-Talk: Cognitive Distortions and Imposter Fears | 7/13/2021 | 7/15/2021 |
 | Week 3 - III. Self-Advocacy and Assertiveness | 7/20/2021 | 7/22/2021 |

--- a/_events/202176-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
+++ b/_events/202176-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
@@ -16,8 +16,7 @@ updated_at: 2021-05-12 16:56:51.000000000 Z
 **We will be doing this orientation virtually, please register here and
 we will make sure you get the link to join.**
 
-**\*\*NOTE: This Orientation is for <span style="text-decoration:
-underline;">Graduate Students and Postdocs </span>\*\***
+**\*\*NOTE: This Orientation is for <span>Graduate Students and Postdocs </span>\*\***
 
 Just arrived at the NIH? Wondering how to make the most of your time
 here? Want to set goals and establish expectations with your mentor?

--- a/_events/202177-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch-nourish-to-flourish-a-self-care-workshop-on-avoiding-burnout.md
+++ b/_events/202177-nih-sacnas-society-for-the-advancement-of-chicanos-hispanics-and-native-americans-in-science-chapter-virtual-lunch-nourish-to-flourish-a-self-care-workshop-on-avoiding-burnout.md
@@ -43,7 +43,7 @@ prior to the event.
 For any questions, please contact Dr. Natasha Lugo-Escobar at
 lugoescobarn@mail.nih.gov.  
 
-<span style="font-size: 8pt;">Who are we?: We are a professional SACNAS
+<span>Who are we?: We are a professional SACNAS
 chapter that provides a supportive and welcoming environment for
 Hispanics/Chicanos and Native Americans trainees and staff at the NIH to
 get together, exchange ideas, network, share successes, and strategize

--- a/_events/202178-management-boot-camp-july-2021.md
+++ b/_events/202178-management-boot-camp-july-2021.md
@@ -23,7 +23,7 @@ environment.  The topics covered will be applicable to all sectors
 This course requires a commitment of multiple days. Directions for
 applying to the course are below.   
 
-<span style="text-decoration: underline;">**This will be offered via
+<span>**This will be offered via
 zoom**</span>
 
 **Course Schedule:**

--- a/_events/2021810-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
+++ b/_events/2021810-discussion-for-building-resilience-anxiety-depression-and-other-challenges.md
@@ -36,6 +36,6 @@ resilience and self-care skills with other trainees having similar
 experiences.  Even if you can\'t join us for the entire hour, we
 encourage you to still attend.  
 
-<span style="font-size: 10pt;"> </span>
+<span> </span>
 
  

--- a/_events/2021810-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
+++ b/_events/2021810-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
@@ -16,8 +16,7 @@ updated_at: 2021-07-21 18:11:30.000000000 Z
 **We will be doing this orientation virtually, please register here and
 we will make sure you get the link to join.**
 
-**\*\*NOTE: This Orientation is for <span style="text-decoration:
-underline;">Graduate Students and Postdocs </span>\*\***
+**\*\*NOTE: This Orientation is for <span>Graduate Students and Postdocs </span>\*\***
 
 Just arrived at the NIH? Wondering how to make the most of your time
 here? Want to set goals and establish expectations with your mentor?

--- a/_events/2021813-md-and-md-phd-application-q-a-session.md
+++ b/_events/2021813-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-07-24 14:25:01.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/2021826-discussion-for-building-resilience-lgbtqia-trainees.md
+++ b/_events/2021826-discussion-for-building-resilience-lgbtqia-trainees.md
@@ -37,8 +37,7 @@ confidential space to explore positive and proactive ways to build
 resilience and self-care skills. Even if you can\'t join us for the
 entire hour, we encourage you to still attend. 
 
-<span style="font-family: arial, helvetica, sans-serif; font-size:
-10pt;"> </span>
+<span> </span>
 
  
 

--- a/_events/2021827-md-and-md-phd-application-q-a-session.md
+++ b/_events/2021827-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-07-24 14:26:05.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/2021910-md-and-md-phd-application-q-a-session.md
+++ b/_events/2021910-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-07-24 14:26:47.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/2021924-md-and-md-phd-application-q-a-session.md
+++ b/_events/2021924-md-and-md-phd-application-q-a-session.md
@@ -12,18 +12,16 @@ topic:
 - Professional (Medical/Dental) School
 updated_at: 2021-07-24 14:27:15.000000000 Z
 ---
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">During these virtual Q&amp;A sessions the pre-medical team will
+<span>During these virtual Q&amp;A sessions the pre-medical team will
 answer questions about the medical school application, AMCAS and MCAT
 updates, and other general questions. We are going to be meeting every
 other week. These sessions are not consecutive, so you can attend one or
 more, and as many as you want. </span>
-{: style="vertical-align: baseline; margin: 0in 0in .2in 0in;"}
 
-<span style="font-size: 8.5pt; font-family: 'Verdana',sans-serif; color:
-black;">If you are interested, please register in advance, as we will be
+
+<span>If you are interested, please register in advance, as we will be
 sending the zoom link to all people registered an hour before the
 session. </span>
-{: style="vertical-align: baseline; outline: 0px; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; widows: 2; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial; word-spacing: 0px; margin: 0in 0in .2in 0in;"}
+
 
  

--- a/_events/202197-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
+++ b/_events/202197-oite-orientation-for-graduate-students-and-postdoctoral-fellows.md
@@ -16,8 +16,7 @@ updated_at: 2021-05-12 16:59:32.000000000 Z
 **We will be doing this orientation virtually, please register here and
 we will make sure you get the link to join.**
 
-**\*\*NOTE: This Orientation is for <span style="text-decoration:
-underline;">Graduate Students and Postdocs </span>\*\***
+**\*\*NOTE: This Orientation is for <span>Graduate Students and Postdocs </span>\*\***
 
 Just arrived at the NIH? Wondering how to make the most of your time
 here? Want to set goals and establish expectations with your mentor?


### PR DESCRIPTION
closes: https://trello.com/c/zQIu0cWi/215-potential-bug-style-src-csp-violation-for-underlined-text-out-of-netlify

Ran a quick regex find-and-replace to remove style attributes that weren't getting applied anyway due to CSP settings. This still leaves behind a lot of useless `<span>` elements, but this felt like the right balance between cleaning up the warnings and not spending too much time hand-editing all of these files.

I verified that styles are properly applied for anything that uses proper markdown syntax