### PR TITLE
CMS: Fix issue serializing Kramdown extensions

### DIFF
--- a/app/javascript/ColumnsEditorComponent/TwoColumns.test.jsx
+++ b/app/javascript/ColumnsEditorComponent/TwoColumns.test.jsx
@@ -18,7 +18,8 @@ Here is some preamble text
 {::columns span="6,6"}
 {::column}
 Here is the left column content
-It is spread across multiple lines.
+{::video url="https://www.youtube.com/watch?v=SAK117AmzSE" /}
+(That was a video)
 {:/column}
 {::column}
 Here is the right column content
@@ -32,7 +33,7 @@ Here is the right column content
       expect(m).toBeTruthy();
       const data = TwoColumns.fromBlock(m);
       expect(data).toStrictEqual({
-        left: "\nHere is the left column content\nIt is spread across multiple lines.\n",
+        left: '\nHere is the left column content\n{::video url="https://www.youtube.com/watch?v=SAK117AmzSE"/}\n(That was a video)\n',
         right: "\nHere is the right column content\n",
       });
     });

--- a/app/javascript/kramdown/index.js
+++ b/app/javascript/kramdown/index.js
@@ -23,7 +23,7 @@ export function serializeKramdownExtensionNodes(nodes) {
         return node;
       }
       const attributes = node.attributes
-        .map(({ name, value }) => `${name}="${escape(value)}"`)
+        .map(({ name, value }) => `${name}="${escapeForAttribute(value)}"`)
         .join(" ");
       const startOpen = `{::${node.name}${
         attributes === "" ? "" : " "


### PR DESCRIPTION
Use `escapeForAttribute` instead of just `escape`. This was the root of some issues with video embeds not working in columns.

Closes: https://trello.com/c/Oqjnzmup/240-embed-videos-in-columns