### PR TITLE
Clean up fields on page editor

### DIFF
--- a/_pages/contact/index.md
+++ b/_pages/contact/index.md
@@ -1,7 +1,9 @@
 ---
 title: Contact
-public: true
-expires_at: ""
+access:
+  public: true
+lifecycle:
+  expires_at: ""
 updated_at: 2022-04-26T00:00:00.000Z
 ---
 Contact us using a method to be determined.

--- a/_pages/events/index.md
+++ b/_pages/events/index.md
@@ -1,9 +1,9 @@
 ---
 title: Events
-public: true
-expires_at: ""
-sidebar:
-  - block: hours-location/block
+access:
+  public: true
+lifecycle:
+  expires_at: ""
 updated_at: 2022-04-26T00:00:00.000Z
 ---
 This is the events page. This preamble is editable in the CMS.

--- a/_pages/expiration-testing/index.md
+++ b/_pages/expiration-testing/index.md
@@ -1,7 +1,9 @@
 ---
 title: Expiring Post
-public: true
-expires_at: 2022-03-17T20:30:00.000Z
+access:
+  public: true
+lifecycle:
+  expires_at: 2022-03-17T20:30:00.000Z
 updated_at: 2022-04-26T00:00:00.000Z
 ---
 This page will expire at 4:30pm on March 17, 2022.

--- a/_pages/home/index.md
+++ b/_pages/home/index.md
@@ -1,7 +1,9 @@
 ---
 title: Home
-public: true
-expires_at: ""
+access:
+  public: true
+lifecycle:
+  expires_at: ""
 updated_at: 2022-04-26T00:00:00.000Z
 ---
 This is the home page!

--- a/_pages/non-discrimination-policy/index.md
+++ b/_pages/non-discrimination-policy/index.md
@@ -1,7 +1,9 @@
 ---
 title: Non-discrimination policy
-public: true
-expires_at: ""
+access:
+  public: true
+lifecycle:
+  expires_at: ""
 updated_at: 2022-04-26T00:00:00.000Z
 ---
 Non-discrimination policy consectetur et elit eiusmod aliquip eu esse duis et cillum. Pariatur reprehenderit excepteur sit laborum anim ut officia id veniam id. Irure pariatur et ea voluptate pariatur cillum eu. Et enim magna deserunt ipsum laborum eiusmod nisi irure commodo ex et eiusmod. Sunt sunt aliquip laborum duis duis sint sint. Irure reprehenderit eiusmod cillum in esse nisi aliquip consequat ex deserunt reprehenderit. Esse occaecat ut aliquip aute irure nulla sit nostrud voluptate mollit proident minim fugiat.

--- a/_pages/privacy/index.md
+++ b/_pages/privacy/index.md
@@ -1,7 +1,9 @@
 ---
 title: Privacy notice
-public: true
-expires_at: ""
+access:
+  public: true
+lifecycle:
+  expires_at: ""
 updated_at: 2022-04-26T00:00:00.000Z
 ---
 Privacy notice occaecat quis aliqua consequat incididunt sit irure occaecat deserunt nulla ea anim. Laborum id voluptate ullamco sunt occaecat ipsum culpa dolore mollit. Velit dolor reprehenderit ut nulla duis aliquip sunt officia dolor aute. Veniam consectetur qui exercitation culpa officia culpa nostrud nulla minim commodo consequat excepteur eiusmod labore. Proident anim enim irure reprehenderit sint quis Lorem consequat eiusmod. Pariatur aliqua nisi minim cupidatat laborum id consequat.

--- a/_pages/private/index.md
+++ b/_pages/private/index.md
@@ -1,6 +1,7 @@
 ---
 title: Private Page
-public: false
+access:
+  public: false
 updated_at: 2022-04-26T00:00:00.000Z
 ---
 This page is unavailable to guest users

--- a/_pages/public-page/index.md
+++ b/_pages/public-page/index.md
@@ -1,7 +1,9 @@
 ---
 title: Public page
-public: true
-expires_at: ""
+access:
+  public: true
+lifecycle:
+  expires_at: ""
 sidebar:
   - block: hours-location/block
 updated_at: 2022-04-26T00:00:00.000Z

--- a/_pages/training/index.md
+++ b/_pages/training/index.md
@@ -1,4 +1,5 @@
 ---
 title: Training
-public: true
+access:
+  public: true
 ---

--- a/_pages/training/postbac/about/index.md
+++ b/_pages/training/postbac/about/index.md
@@ -1,6 +1,7 @@
 ---
 title: About the National Institutes of Health (NIH) Postbaccalaureate Research Training Program
-public: true
+access:
+  public: true
 nav:
   title: About
   order: 0

--- a/_pages/training/postbac/after-you-apply/index.md
+++ b/_pages/training/postbac/after-you-apply/index.md
@@ -3,5 +3,6 @@ title: Next steps after you apply to the National Institutes of Health (NIH) Pos
 nav:
   title: After you apply
   order: 30
-public: true
+access:
+  public: true
 ---

--- a/_pages/training/postbac/eligibility/index.md
+++ b/_pages/training/postbac/eligibility/index.md
@@ -3,5 +3,6 @@ title: Eligiblity requirements for National Institutes of Health (NIH) Postbacca
 nav:
   title: Eligiblity
   order: 10
-public: true
+access:
+  public: true
 ---

--- a/_pages/training/postbac/index.md
+++ b/_pages/training/postbac/index.md
@@ -1,7 +1,9 @@
 ---
 title: Postbac Research Training Program
-public: true
-expires_at: 2020-01-01 00:00:00
-redirect_to: training/postbac/about/index
+access:
+  public: true
+lifecycle:
+  expires_at: 2020-01-01 00:00:00
+  redirect_to: training/postbac/about/index
 ---
 

--- a/_pages/training/postbac/selection/index.md
+++ b/_pages/training/postbac/selection/index.md
@@ -3,5 +3,6 @@ title: How applicants are selected for National Institutes of Health (NIH) Postb
 nav:
   title: How applicants are selected
   order: 20
-public: true
+access:
+  public: true
 ---

--- a/_pages/wellness/index.md
+++ b/_pages/wellness/index.md
@@ -1,8 +1,10 @@
 ---
 title: Wellness
-public: true
-expires_at: ""
-redirect_to: wellness/mindfulness/index
+access:
+  public: true
+lifecycle:
+  expires_at: ""
+  redirect_to: wellness/mindfulness/index
 updated_at: 2022-04-26T00:00:00.000Z
 ---
 You should be redirected to [mindfulness](/wellness/mindfulness)

--- a/_pages/wellness/meditation/index.md
+++ b/_pages/wellness/meditation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Meditation
-public: true
+access:
+  public: true
 updated_at: 2022-04-26T00:00:00.000Z
 ---
 

--- a/_pages/wellness/mindfulness/index.md
+++ b/_pages/wellness/mindfulness/index.md
@@ -1,6 +1,7 @@
 ---
 title: Mindfulness
-public: true
+access:
+  public: true
 updated_at: 2022-04-26T00:00:00.000Z
 ---
 

--- a/app/models/concerns/netlify_content.rb
+++ b/app/models/concerns/netlify_content.rb
@@ -33,10 +33,17 @@ module NetlifyContent
       end
     end
 
-    def has_field(*fields, default: nil)
+    def has_field(*fields, through: nil, default: nil)
       fields.each do |field_name|
         define_method field_name do
-          parsed_file[field_name.to_s] || default
+          container = parsed_file
+
+          if through.present?
+            container = parsed_file[through.to_s]
+            return default unless container
+          end
+
+          container[field_name.to_s] || default
         end
       end
     end

--- a/app/models/concerns/netlify_content.rb
+++ b/app/models/concerns/netlify_content.rb
@@ -43,7 +43,9 @@ module NetlifyContent
             return default unless container
           end
 
-          container[field_name.to_s] || default
+          field_name = field_name.to_s.sub "?", ""
+
+          container[field_name] || default
         end
       end
     end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -66,9 +66,9 @@ class Page
   attr_reader :filename, :base
   attr_writer :children
   attr_accessor :parent
-  has_field :expires_at, through: :lifecycle
+  has_field :expires_at, :redirect_to, through: :lifecycle
   has_field :public?, through: :access, default: false
-  has_field :title, :redirect_to
+  has_field :title
   has_field :sidebar, default: []
 
   def initialize(full_path, base:)
@@ -115,19 +115,13 @@ class Page
   end
 
   def redirect_page
-    lifecycle = parsed_file["lifecycle"]
-    return nil if lifecycle.nil?
-
-    if lifecycle["redirect_to"].present?
-      @redirect_page ||= self.class.find_by_path(lifecycle["redirect_to"], base: base, try_index: false).filename
+    if redirect_to.present?
+      @redirect_page ||= self.class.find_by_path(redirect_to, base: base, try_index: false).filename
     end
   end
 
   def expired?
-    lifecycle = parsed_file["lifecycle"]
-    return false if lifecycle.nil?
-
-    lifecycle["expires_at"].present? && lifecycle["expires_at"].past?
+    expires_at.present? && expires_at.past?
   end
 
   def has_sidebar?

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -67,7 +67,7 @@ class Page
   attr_writer :children
   attr_accessor :parent
   has_field :expires_at, through: :lifecycle
-  has_field :public, through: :access, default: false
+  has_field :public?, through: :access, default: false
   has_field :title, :redirect_to
   has_field :sidebar, default: []
 

--- a/app/views/pages/netlify_config.yaml.erb
+++ b/app/views/pages/netlify_config.yaml.erb
@@ -83,27 +83,31 @@ collections:
       - {name: "updated_at", label: "Last Updated At", hide_preview: true, required: false, widget: "readonly"}
       - {label: "Content Name", name: "name"}
       - {label: "Body", name: "body", widget: "markdown"}
-  - name: page
-    label: "Page"
+  - name: pages
+    label: "Pages"
+    label_singular: Page
     folder: "_pages/"
     create: true
     nested: {depth: 4}
-    meta: {path: {widget: string, label: "Path", index_file: "index"}}
+    meta:
+      path:
+        label: "Path"
+        widget: string
+        index_file: "index"
     fields:
-      - {label: "Title", name: "title"}
-      - {label: "Public", name: "public", widget: "boolean", default: true}
-      - {label: "Expires At", name: "expires_at", widget: "datetime", default: "", required: false}
-      - label: "Replaced By Page"
-        name: "redirect_to"
-        widget: "relation"
+      - label: "Title"
+        name: "title"
+      - label: Content
+        name: body
+        widget: markdown
         required: false
-        collection: "page"
-        search_fields: ["title", "{{slug}}"]
-        value_field: "{{slug}}"
-        display_fields: ["title", "{{slug}}"]
-      - label: "Sidebar contents"
+      - label: "Sidebar items"
         name: "sidebar"
         widget: list
+        label_singular: item
+        label_plural: items
+        hint: |
+          Sidebar items will be displayed below site navigation in the sidebar.
         min: 0
         fields:
           - name: block
@@ -112,7 +116,6 @@ collections:
             search_fields: ["name", "{{slug}}"]
             value_field: "{{slug}}"
             display_fields: ["name"]
-      - {label: "Body", name: "body", widget: "markdown"}
       - label: Navigation
         name: nav
         widget: object
@@ -132,6 +135,37 @@ collections:
               Order in which this item should be sorted in navigation menus.
               Higher numbers sort after lower numbers.
               If two pages have the same Order, they're sorted alphabetically by title.
+      - label: "Lifecycle"
+        name: "lifecycle"
+        widget: object
+        collapsed: true
+        summary: "Expires: {{fields.expires_at | default('never')}}"
+        fields:
+        - label: "Expires At"
+          name: expires_at
+          widget: "datetime"
+          default: ""
+          required: false
+        - label: "Replaced by Page"
+          name: "redirect_to"
+          widget: "relation"
+          required: false
+          collection: "page"
+          search_fields: ["title", "{{slug}}"]
+          value_field: "{{slug}}"
+          display_fields: ["title", "{{slug}}"]
+      - label: "Access control"
+        name: access
+        widget: object
+        collapsed: true
+        summary: "{{fields.public | ternary('Public','Private (visible to logged-in users only)')}}"
+        fields:
+        - label: Public
+          name: public
+          widget: boolean
+          default: true
+          hint: |
+            Public pages are visible to all users. Private pages are only visible to logged-in users.
       - {name: "updated_by", label: "Last Updated By", hide_preview: true, required: false, widget: "readonly"}
       - {name: "updated_at", label: "Last Updated At", hide_preview: false, required: false, widget: "readonly"}
   - name: settings

--- a/app/views/pages/netlify_config.yaml.erb
+++ b/app/views/pages/netlify_config.yaml.erb
@@ -150,7 +150,7 @@ collections:
           name: "redirect_to"
           widget: "relation"
           required: false
-          collection: "page"
+          collection: "pages"
           search_fields: ["title", "{{slug}}"]
           value_field: "{{slug}}"
           display_fields: ["title", "{{slug}}"]
@@ -188,7 +188,7 @@ collections:
             fields:
               - name: page
                 widget: relation
-                collection: page
+                collection: pages
                 value_field: "{{slug}}"
                 display_fields: ["{{title}} ({{slug}})"]
                 search_fields: ["title"]

--- a/app/views/pages/netlify_config.yaml.erb
+++ b/app/views/pages/netlify_config.yaml.erb
@@ -139,7 +139,7 @@ collections:
         name: "lifecycle"
         widget: object
         collapsed: true
-        summary: "Expires: {{fields.expires_at | default('never')}}"
+        summary: "Expires: {{fields.expires_at | default('never')}}, replaced by: {{fields.redirect_to | default('nothing')}}"
         fields:
         - label: "Expires At"
           name: expires_at

--- a/spec/fixtures/files/_pages/page-one/index.md
+++ b/spec/fixtures/files/_pages/page-one/index.md
@@ -1,7 +1,9 @@
 ---
 title: "Page One"
-public: true
-expires_at: ""
+access:
+  public: true
+lifecycle:
+  expires_at: ""
 sidebar:
   - block: hours-location/block
 ---

--- a/spec/fixtures/files/_pages/page-two/index.md
+++ b/spec/fixtures/files/_pages/page-two/index.md
@@ -1,8 +1,10 @@
 ---
 title: "Page Two"
-public: false
-expires_at: 2022-03-17T20:30:00.000Z
-redirect_to: page-one/index
+access:
+  public: false
+lifecycle:
+  expires_at: 2022-03-17T20:30:00.000Z
+  redirect_to: page-one/index
 ---
 
 This is page two

--- a/spec/fixtures/files/_pages/private-page/index.md
+++ b/spec/fixtures/files/_pages/private-page/index.md
@@ -1,8 +1,10 @@
 ---
 title: "Private Page"
-public: false
-expires_at: ""
-redirect_to: ""
+access:
+  public: false
+lifecycle:
+  expires_at: ""
+  redirect_to: ""
 ---
 
 This is a private page.

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -99,6 +99,12 @@ RSpec.describe Page, type: :model do
     end
   end
 
+  describe "#redirect_to" do
+    it "returns the slug of the redirected-to page" do
+      expect(subject.redirect_to).to eq("page-one/index")
+    end
+  end
+
   describe "#redirect_page" do
     it "returns the filename of the redirected-to page" do
       expect(subject.redirect_page).to eq Pathname.new("page-one")


### PR DESCRIPTION
This PR gathers expiration and access control related fields and moves them to the bottom of the Netlify editor page for the "Page" content type:

<img width="836" alt="image" src="https://user-images.githubusercontent.com/364697/168379268-1807caff-09fb-4ea9-b71c-b2edae3ae53b.png">

(It also collapses them by default)

I used the `object` widget to do this, which meant that field names in front matter changed slightly (this is why there are so many .md files in this PR):

- `public` is now part of an `access` object
- `expires_at` and `redirect_to` are now part of a `lifecycle` object

I added a `through:` argument to `has_field` to facilitate reading these a little bit. The actual Ruby `Page` model's API is unchanged.

Will close https://trello.com/c/19quaCIz/242-organize-fields-on-the-page-editor-cms-page
