### PR TITLE
Specify HTML titles for every page

### DIFF
--- a/.env
+++ b/.env
@@ -16,3 +16,6 @@ GIT_GATEWAY_HOST=http://localhost:9999/
 
 # SEARCH_GOV_AFFILIATE to return the correct site in search.gov results
 SEARCH_GOV_AFFILIATE=nihoitestaging
+
+# SITEMAP_LAST_MOD_OVERRIDE is the oldest date that sitemap.xml will claim any page is. iso8601 format
+SITEMAP_LAST_MOD_OVERRIDE=2022-05-19T13:47:19Z

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -60,5 +60,6 @@ class EventsController < ApplicationController
 
   def show
     @event = Event.find_by_path(params[:id])
+    @page_title = "#{@event.title} | #{@event.date.strftime("%-m/%-d/%Y")}"
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,6 +9,7 @@ class PagesController < ApplicationController
   end
 
   def home
+    @page_title = "Home"
   end
 
   def page
@@ -23,9 +24,9 @@ class PagesController < ApplicationController
 
     if @page.public? || user_signed_in?
       @side_nav_items = Menu.build_side_nav @pages, @page
-
       @show_sidebar = @page.has_sidebar? || @side_nav_items.length > 0
 
+      @page_title = @page.title
       render formats: :html
     else
       store_location_for(:user, "/#{params[:path]}")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,11 +21,16 @@ module ApplicationHelper
     unless page.obsolete? || !page.public?
       builder.url do
         builder.loc content_page_url(path: page.filename)
-        builder.lastmod page.updated_at&.xmlschema
+        builder.lastmod overridden_last_modified_date(page.updated_at)
       end
     end
     page.children.each do |child|
       page_sitemap(child, builder)
     end
+  end
+
+  def overridden_last_modified_date(updated_at = nil)
+    override = Time.parse(ENV["SITEMAP_LAST_MOD_OVERRIDE"]) if ENV["SITEMAP_LAST_MOD_OVERRIDE"].present?
+    [override, updated_at].compact.max&.xmlschema
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,10 @@
 require "yaml"
 
 module ApplicationHelper
+  def page_title
+    "#{@page_title || params[:controller].titleize} | NIH OITE"
+  end
+
   def pages
     @pages ||= Page.build_hierarchy Rails.root.join "_pages"
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="<%= I18n.locale %>">
   <head>
-    <title>NIH OITE Experiments</title>
+    <title><%= page_title %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/pages/sitemap.xml.builder
+++ b/app/views/pages/sitemap.xml.builder
@@ -2,6 +2,7 @@ xml.instruct!
 xml.urlset do
   xml.url do
     xml.loc root_url
+    xml.lastmod overridden_last_modified_date
   end
   pages.each do |page|
     page_sitemap(page, xml)
@@ -9,7 +10,7 @@ xml.urlset do
   Event.all(from: Date.today - 90).each do |event|
     xml.url do
       xml.loc event_url(event)
-      xml.lastmod event.updated_at&.xmlschema
+      xml.lastmod overridden_last_modified_date(event.updated_at)
     end
   end
 end

--- a/config/deployment/staging.yml
+++ b/config/deployment/staging.yml
@@ -6,3 +6,4 @@ worker_memory: 256M
 netlify_branch: main
 git_gateway_host: http://nih_oite_experiments-staging-gateway.apps.internal:8080/
 search_gov_affiliate: nihoitestaging
+sitemap_last_mod_override: "2022-05-19T13:47:19Z"

--- a/manifest.yml
+++ b/manifest.yml
@@ -13,6 +13,7 @@ applications:
     NETLIFY_BRANCH: ((netlify_branch))
     GIT_GATEWAY_HOST: ((git_gateway_host))
     SEARCH_GOV_AFFILIATE: ((search_gov_affiliate))
+    SITEMAP_LAST_MOD_OVERRIDE: ((sitemap_last_mod_override))
   routes:
     - route: nih_oite_experiments-((env)).app.cloud.gov
     - route: nih-oite-experiments-((env)).app.cloud.gov

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe "#overridden_last_modified_date" do
+    let(:updated_at) { 1.week.ago }
+
+    context "no ENV override" do
+      around do |example|
+        ClimateControl.modify SITEMAP_LAST_MOD_OVERRIDE: "" do
+          example.run
+        end
+      end
+
+      it "returns the given time in iso8601 format" do
+        expect(helper.overridden_last_modified_date(updated_at)).to eq updated_at.xmlschema
+      end
+
+      it "returns nil if both values are blank" do
+        expect(helper.overridden_last_modified_date).to be_nil
+      end
+    end
+
+    context "last modified overridden" do
+      let(:override) { 2.weeks.ago.xmlschema }
+      around do |example|
+        ClimateControl.modify SITEMAP_LAST_MOD_OVERRIDE: override do
+          example.run
+        end
+      end
+
+      it "returns the override when the given date is before the override" do
+        expect(helper.overridden_last_modified_date(3.weeks.ago)).to eq override
+      end
+
+      it "returns the given date when the given date is after the override" do
+        expect(helper.overridden_last_modified_date(updated_at)).to eq updated_at.xmlschema
+      end
+    end
+  end
+end

--- a/spec/views/pages/home.html.erb_spec.rb
+++ b/spec/views/pages/home.html.erb_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "pages/home.html.erb", type: :view do
   it "displays the gov banner" do
+    assign :page_title, "Title"
     render template: "pages/home", layout: "layouts/application"
     expect(rendered).to match "An official website of the United States government"
   end


### PR DESCRIPTION
Changes:

* set a page title on each individual page
  * Uses the `title` field for things in the Pages collection
  * Uses a combination of the `name` field and `date` for Events
* allow overriding the `lastmod` date in the sitemap so that search.gov picks up the new changes.

Closes: https://trello.com/c/n1Ew7fIX/239-page-titles-for-events