### PR TITLE
Handle missing events files with 404 response

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -61,5 +61,7 @@ class EventsController < ApplicationController
   def show
     @event = Event.find_by_path(params[:id])
     @page_title = "#{@event.title} | #{@event.date.strftime("%-m/%-d/%Y")}"
+  rescue Event::NotFound
+    raise ActionController::RoutingError.new("Not Found")
   end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -16,5 +16,11 @@ RSpec.describe "Events", type: :request do
       get "/events/202257-training-event"
       expect(response).to render_template :show
     end
+
+    it "returns a 404 error when the event isn't found" do
+      expect {
+        get "/events/202211-notfound"
+      }.to raise_error(ActionController::RoutingError)
+    end
   end
 end


### PR DESCRIPTION
Bugfix

Closes: https://trello.com/c/zG7qfwTm/248-typos-in-events-routes-should-return-404-errors-not-500

Previously, visiting an events URL that didn't exist resulted in a 500 (Internal Server Error) error, which is not a friendly error message for the user

Now, visiting an events URL that doesn't exist will result in a 404 (Page Not Found) error