### PR TITLE
Add support for NIH Videocast embeds

### DIFF
--- a/app/controllers/concerns/video_embeddable.rb
+++ b/app/controllers/concerns/video_embeddable.rb
@@ -3,7 +3,7 @@ module VideoEmbeddable
 
   included do
     content_security_policy do |policy|
-      policy.frame_src "https://www.youtube-nocookie.com"
+      policy.frame_src "https://www.youtube-nocookie.com", "https://videocast.nih.gov"
     end
   end
 end

--- a/app/javascript/VideoEditorComponent.jsx
+++ b/app/javascript/VideoEditorComponent.jsx
@@ -26,6 +26,30 @@ const VIDEO_TYPES = [
       );
     },
   },
+  {
+    id: "nih-videocast",
+    pattern: "https:\\/\\/videocast\\.nih\\.gov\\/watch=(\\d+)",
+    generatePreview(url, alt) {
+      const m = /^\/watch=(\d+)$/.exec(new URL(url).pathname);
+      const videoId = m[1];
+
+      const embedUrl = `https://videocast.nih.gov/embed.asp?live=${videoId}`;
+
+      return (
+        <div className="video">
+          <iframe
+            width="560"
+            height="315"
+            src={embedUrl}
+            title={alt}
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          />
+        </div>
+      );
+    },
+  },
 ];
 
 const VideoEditorComponent = createKramdownExtensionEditorComponent({
@@ -34,8 +58,9 @@ const VideoEditorComponent = createKramdownExtensionEditorComponent({
   fields: [
     {
       name: "url",
-      label: "Youtube URL",
+      label: "Video URL",
       widget: "string",
+      hint: "Youtube or NIH Videocast URLs are supported.",
     },
     {
       name: "alt",

--- a/app/javascript/VideoEditorComponent.test.jsx
+++ b/app/javascript/VideoEditorComponent.test.jsx
@@ -76,6 +76,23 @@ describe("VideoEditorComponent", () => {
         ),
       },
       {
+        url: "https://videocast.nih.gov/watch=44332",
+        alt: "some alt text",
+        expected: (
+          <div className="video">
+            <iframe
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+              frameBorder="0"
+              height="315"
+              src="https://videocast.nih.gov/embed.asp?live=44332"
+              title="some alt text"
+              width="560"
+            />
+          </div>
+        ),
+      },
+      {
         url: "https://example.org/not-a-video",
         alt: "some alt text",
         expected: <div>Unrecognized video url</div>,

--- a/bin/with-server
+++ b/bin/with-server
@@ -22,13 +22,16 @@ bundle exec rails server &
 server_pid=$!
 
 dockerize -wait http://localhost:3000 -timeout 1m
-
-$@
 exit_status=$?
+
+if [[ $exit_status -eq 0 ]]; then
+  $@
+  exit_status=$?
+fi
 
 
 # shut down the server and cleanup after ourselves
-bundle exec rake assets:clobber
 kill $server_pid
+bundle exec rake assets:clobber
 
 exit $exit_status

--- a/zap.conf
+++ b/zap.conf
@@ -121,3 +121,4 @@
 90034	WARN	(Cloud Metadata Potentially Exposed - Active/beta)
 10202	OUTOFSCOPE	http://.*:3000/events.*
 20012	OUTOFSCOPE	http://.*:3000/events.*
+10062	OUTOFSCOPE	http://.*:3000/users/auth/github


### PR DESCRIPTION
Allow embedding NIH Videocast videos by URL, similar to Youtube videos. Supports video URLs in the format provided by the VC site, e.g. `https://videocast.nih.gov/watch=45108`.

## Screenshot

![screenshot](https://user-images.githubusercontent.com/364697/170148708-b1412de5-647e-403a-ae57-1be2f59b1ae2.png)

Closes https://trello.com/c/CCSKjtBN/204-video-provider-nih-videocast