### PR TITLE
Update netlify_config.yaml.erb

### DIFF
--- a/app/views/pages/netlify_config.yaml.erb
+++ b/app/views/pages/netlify_config.yaml.erb
@@ -138,7 +138,7 @@ collections:
         widget: markdown
         required: false
       - label: "Sidebar items"
-        name: "sidebar"
+        name: "sidebar_blocks"
         widget: list
         label_singular: item
         label_plural: items


### PR DESCRIPTION
As part of #13 I renamed `sidebar` to `sidebar_blocks` to make it consistent with `top_blocks` and `bottom_blocks`, but I neglected to update it here. This resulted in pages not correctly showing their sidebar items in the Netlify editor.