### PR TITLE
Prevent entire homepage from crashing when issue loading blog headlines

### DIFF
--- a/app/models/blog_headlines_block.rb
+++ b/app/models/blog_headlines_block.rb
@@ -1,10 +1,12 @@
 class BlogHeadlinesBlock
   OITE_BLOG_FEED = "https://oitecareersblog.od.nih.gov/feed/".freeze
 
-  attr_reader :headlines
   def initialize(post_count)
     @post_count = post_count.to_i
-    @headlines = read_rss
+  end
+
+  def headlines
+    @headlines ||= read_rss
   end
 
   def parse(template)
@@ -21,6 +23,9 @@ class BlogHeadlinesBlock
     else
       []
     end
+  rescue => ex
+    Rails.logger.error { "Error loading OITE Blog headlines: #{ex.message}" }
+    []
   end
 
   class BlogPost


### PR DESCRIPTION
cloud.gov is looking into why we can't access the blog from the deployed app, but in the meantime this sort of defensive coding should have been in place from the beginning.