### PR TITLE
Enable local site demonstrations via Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ruby:3.1.1
+
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -\
+  && apt-get update -qq && apt-get install -qq --no-install-recommends \
+    nodejs postgresql-client \
+  && apt-get upgrade -qq \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*\
+  && npm install -g yarn@1
+
+WORKDIR /app
+
+COPY Gemfile Gemfile.lock /app/
+RUN bundle install
+
+COPY package.json yarn.lock /app/
+RUN yarn install
+
+COPY . /app/
+
+ENV RAILS_ENV development
+RUN bundle exec rake assets:precompile
+
+CMD bundle exec rails server -b 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -3,6 +3,21 @@ NIH OITE Website
 
 This application is one option for the groundwork for the new NIH OITE website.
 
+## Docker use
+
+Docker files exist to make it easy to run the application via Docker, but it is not (yet) setup to be easy to do development inside the docker containers.
+
+To run the app via docker:
+
+1. Copy `env.gitgateway.example` to `.env.gitgateway.local`
+1. Update the two `CHANGE ME` values within `.env.gitgateway.local`
+1. Run `docker compose up --build`
+1. First time setup:
+    1. Run `docker compose run web bundle exec rake db:create`
+    1. Run `docker compose run web bundle exec rake db:migrate`
+1. Open <http://localhost:3000> in your web browser
+
+
 ## Development
 
 If you're new to Rails, see the [Getting Started with Rails](https://guides.rubyonrails.org/getting_started.html)

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,7 +19,8 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
+  host: <%= ENV.fetch("DB_HOSTNAME", "localhost") %>
 
 development:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.6'
+services:
+  web:
+    build: .
+    environment:
+      DB_HOSTNAME: db
+      GIT_GATEWAY_HOST: "http://gateway:9999/"
+    volumes:
+    - dbrun:/var/run/postgresql
+    depends_on:
+      - db
+      - gateway
+    ports:
+    - "3000:3000"
+  db:
+    image: postgres:12.11
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+    - dbdata:/var/lib/postgresql/data
+    - dbrun:/var/run/postgresql
+  gateway:
+    image: rcahearngsa/netlify-git-gateway
+    env_file:
+      - .env.gitgateway.local
+
+volumes:
+  dbdata: {}
+  dbrun: {}

--- a/env.gitgateway.example
+++ b/env.gitgateway.example
@@ -1,0 +1,11 @@
+# Example env file for running docker compose up
+# Copy this file to `.env.gitgateway.local` and then fill in the values
+
+# the repo that netlify should be operating on
+GITGATEWAY_GITHUB_REPO=HHS/nih-oite-website
+
+# JWT Verification secret, should be the same as what is in `rails credentials:show`
+GITGATEWAY_JWT_SECRET="CHANGE ME"
+
+# Github access token for the repo admin user that netlify acts as
+GITGATEWAY_GITHUB_ACCESS_TOKEN="CHANGE ME"


### PR DESCRIPTION
This `Dockerfile` and `docker-compose.yml` will make it easier to run the site for demonstration purposes for anyone with a passing familiarity with [Docker](https://www.docker.com/).

Closes #123 